### PR TITLE
fix(devadmin): enforce PHP 5

### DIFF
--- a/api/desecapi/models.py
+++ b/api/desecapi/models.py
@@ -128,13 +128,15 @@ class Domain(models.Model):
         if new_domain:
             pdns.create_zone(self.name)
 
-        # for existing domains, see if records are changed
-        if not new_domain:
+        # check if current A and AAAA record values require updating pdns
+        if new_domain:
+            changes_required = bool(self.arecord) or bool(self.aaaarecord)
+        else:
             orig_domain = Domain.objects.get(id=self.id)
             changes_required = self.arecord != orig_domain.arecord or self.aaaarecord != orig_domain.aaaarecord
 
         # make changes if necessary
-        if changes_required or new_domain:
+        if changes_required:
             pdns.set_dyn_records(self.name, self.arecord, self.aaaarecord)
 
     def save(self, *args, **kwargs):

--- a/api/desecapi/templates/emails/captcha/content.txt
+++ b/api/desecapi/templates/emails/captcha/content.txt
@@ -1,7 +1,7 @@
 Hello,
 
-your activity on the deSEC dedyn.io dynamic DNS service looks
-suspiciously similar to those of bots. As mass registrations
+Your activity on the deSEC dedyn.io dynamic DNS service looks
+suspiciously similar to the one of bots. As mass registrations
 by bots have been a problem for us in the past, we need to
 ask you to prove you are not a bot by solving a CAPTCHA. Sorry
 to bother you with that!
@@ -12,7 +12,7 @@ Please go to
 
 and unlock your account for future use. Until unlocked, your
 account will be kept in read-only mode, that is, you won't be able
-to register any domains or update IP addresses (or any other
+to register any new domains or update IP addresses (or any other
 records). Accounts that are not unlocked are subject to deletion
 after two weeks.
 
@@ -27,11 +27,11 @@ Cheers,
 Nils
 
 --
-deSEC GbR
+deSEC
 Maybachufer 9
 12047 Berlin
 Germany
 
 phone: +49-30-47384344
 
-Vertreten durch: Jan Binger, Peter Thomassen, Nils Wisiol
+Vertreten durch: Dr. Peter Thomassen, Nils Wisiol

--- a/api/desecapi/templates/emails/domain-dyndns/content.txt
+++ b/api/desecapi/templates/emails/domain-dyndns/content.txt
@@ -31,11 +31,11 @@ Cheers,
 Nils
 
 --
-deSEC GbR
+deSEC
 Maybachufer 9
 12047 Berlin
 Germany
 
 phone: +49-30-47384344
 
-Vertreten durch: Jan Binger, Peter Thomassen, Nils Wisiol
+Vertreten durch: Dr. Peter Thomassen, Nils Wisiol

--- a/api/desecapi/templates/emails/donation/donor-content.txt
+++ b/api/desecapi/templates/emails/donation/donor-content.txt
@@ -14,6 +14,15 @@ appearing on your bank statement.
 
 Again, thank you so much.
 
+Cheers,
+Nils
+
 --
-Nils Wisiol
 deSEC
+Maybachufer 9
+12047 Berlin
+Germany
+
+phone: +49-30-47384344
+
+Vertreten durch: Dr. Peter Thomassen, Nils Wisiol

--- a/devadmin/Dockerfile
+++ b/devadmin/Dockerfile
@@ -1,4 +1,4 @@
-FROM richarvey/nginx-php-fpm
+FROM richarvey/nginx-php-fpm:php5
 
 RUN apk add --no-cache \
 	php5-gettext \


### PR DESCRIPTION
The docker image richarvey/nginx-php-fpm that we're using has switched
its default to PHP 7, breaking the way our poweradmin is set up.

This PR enforces the use of the PHP 5 docker image.