### PR TITLE
fix(api): fix HTTP error codes for basic auth, closes #26

### DIFF
--- a/api/desecapi/authentication.py
+++ b/api/desecapi/authentication.py
@@ -4,6 +4,7 @@ import base64
 from rest_framework import exceptions, HTTP_HEADER_ENCODING
 from rest_framework.authtoken.models import Token
 from rest_framework.authentication import BaseAuthentication, get_authorization_header, authenticate
+from desecapi.models import Domain
 
 
 class BasicTokenAuthentication(BaseAuthentication):
@@ -51,6 +52,12 @@ class BasicTokenAuthentication(BaseAuthentication):
 
         if not token.user.is_active:
             raise exceptions.AuthenticationFailed('User inactive or deleted')
+
+        if user:
+            try:
+                Domain.objects.get(owner=token.user.pk, name=user)
+            except:
+                raise exceptions.AuthenticationFailed('Invalid username')
 
         return token.user, token
 


### PR DESCRIPTION
Problem:
- For dynDNS domain updates: When the basic auth username (signifying
  the domain name) was invalid or missing, we returned 404 so far.
  However, as the user is likely to perceive the domain name as a
  username and the token as the password, 401 is more reasonable.

Solution:
- We now return 401 if the username is invalid.
- If it is missing, we determine the domain name based on the token
  and proceed as usual. If this is ambiguous, we return 409.