### PR TITLE
fix(db): improve foreign keys for dblord/dbmaster

### DIFF
--- a/dblord/initdb.d/11-pdns-lord-REFERENCES.sql
+++ b/dblord/initdb.d/11-pdns-lord-REFERENCES.sql
@@ -1,5 +1,16 @@
 USE pdns;
 
--- As recommended by https://doc.powerdns.com/md/authoritative/backend-generic-mysql/
-ALTER TABLE `records` ADD CONSTRAINT `records_ibfk_1` FOREIGN KEY (`domain_id`) REFERENCES `domains` (`id`) ON DELETE CASCADE;
-ALTER TABLE `domainmetadata` ADD CONSTRAINT `domainmetadata_ibfk_1` FOREIGN KEY (`domain_id`) REFERENCES `domains` (`id`) ON DELETE CASCADE;
+-- From https://github.com/PowerDNS/pdns/blob/8b4208199baae1d8f83e50f2d6b67c0d3344b759/modules/gmysqlbackend/enable-foreign-keys.mysql.sql
+/*
+Using this SQL causes Mysql to create foreign keys on your database. This will
+make sure that no records, comments or keys exists for domains that you already
+removed. This is not enabled by default, because we're not sure what the
+consequences are from a performance point of view. If you do have feedback,
+please let us know how this effects your setup.
+Please note that it's not possible to apply this, before you cleaned up your
+database, as the foreign keys do not exist.
+*/
+ALTER TABLE records ADD CONSTRAINT `records_domain_id_ibfk` FOREIGN KEY (`domain_id`) REFERENCES `domains` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE comments ADD CONSTRAINT `comments_domain_id_ibfk` FOREIGN KEY (`domain_id`) REFERENCES `domains` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE domainmetadata ADD CONSTRAINT `domainmetadata_domain_id_ibfk` FOREIGN KEY (`domain_id`) REFERENCES `domains` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE cryptokeys ADD CONSTRAINT `cryptokeys_domain_id_ibfk` FOREIGN KEY (`domain_id`) REFERENCES `domains` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/dbmaster/initdb.d/11-pdns-master-REFERENCES.sql
+++ b/dbmaster/initdb.d/11-pdns-master-REFERENCES.sql
@@ -1,5 +1,16 @@
 USE pdns;
 
--- As recommended by https://doc.powerdns.com/md/authoritative/backend-generic-mysql/
-ALTER TABLE `records` ADD CONSTRAINT `records_ibfk_1` FOREIGN KEY (`domain_id`) REFERENCES `domains` (`id`) ON DELETE CASCADE;
-ALTER TABLE `domainmetadata` ADD CONSTRAINT `domainmetadata_ibfk_1` FOREIGN KEY (`domain_id`) REFERENCES `domains` (`id`) ON DELETE CASCADE;
+-- From https://github.com/PowerDNS/pdns/blob/8b4208199baae1d8f83e50f2d6b67c0d3344b759/modules/gmysqlbackend/enable-foreign-keys.mysql.sql
+/*
+Using this SQL causes Mysql to create foreign keys on your database. This will
+make sure that no records, comments or keys exists for domains that you already
+removed. This is not enabled by default, because we're not sure what the
+consequences are from a performance point of view. If you do have feedback,
+please let us know how this effects your setup.
+Please note that it's not possible to apply this, before you cleaned up your
+database, as the foreign keys do not exist.
+*/
+ALTER TABLE records ADD CONSTRAINT `records_domain_id_ibfk` FOREIGN KEY (`domain_id`) REFERENCES `domains` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE comments ADD CONSTRAINT `comments_domain_id_ibfk` FOREIGN KEY (`domain_id`) REFERENCES `domains` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE domainmetadata ADD CONSTRAINT `domainmetadata_domain_id_ibfk` FOREIGN KEY (`domain_id`) REFERENCES `domains` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE cryptokeys ADD CONSTRAINT `cryptokeys_domain_id_ibfk` FOREIGN KEY (`domain_id`) REFERENCES `domains` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
Previously, we only had foreign key contraints for the `records` and the `domainmetadata` table.

Now we're also adding them for the `comments` and `cryptokeys` table. The SQL statements are taken from https://github.com/PowerDNS/pdns/blob/master/modules/gmysqlbackend/enable-foreign-keys.mysql.sql