### PR TITLE
cronhook, privacy chores

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
 		mysql-client libmysqlclient-dev \
 		postgresql-client libpq-dev \
 		sqlite3 \
+		cron \
 	--no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /usr/src/app
@@ -14,6 +15,12 @@ WORKDIR /usr/src/app
 COPY requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir --upgrade pip
 RUN pip install --no-cache-dir -r requirements.txt
+
+RUN mkdir /root/cronhook
+ADD ["cronhook/crontab", "cronhook/start-cron.sh", "/root/cronhook/"]
+
+RUN crontab /root/cronhook/crontab
+RUN chmod +x /root/cronhook/start-cron.sh
 
 COPY . /usr/src/app
 

--- a/api/cronhook/crontab
+++ b/api/cronhook/crontab
@@ -1,0 +1,1 @@
+55 2 * * * /usr/local/bin/python3 /usr/src/app/manage.py privacy-chores >> /var/log/cron.log 2>&1

--- a/api/cronhook/start-cron.sh
+++ b/api/cronhook/start-cron.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# start-cron.sh
+
+printenv >> /etc/environment
+touch /var/log/cron.log
+cron
+tail -F -v /var/log/cron.log

--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -6,6 +6,9 @@ host=dbapi; port=3306; n=120; i=0; while ! (echo > /dev/tcp/$host/$port) 2> /dev
 # wait for pdns api to come up
 host=nslord; port=8081; n=120; i=0; while ! (echo > /dev/tcp/$host/$port) 2> /dev/null; do [[ $i -eq $n ]] && >&2 echo "$host:$port not up after $n seconds, exiting" && exit 1; echo "waiting for $host:$port to come up"; sleep 1; i=$((i+1)); done
 
+# start cron
+/root/cronhook/start-cron.sh &
+
 # migrate database
 python manage.py migrate || exit 1
 


### PR DESCRIPTION
Added cronhook that executs the privacy chores.

Chosen 2:55am UTC without any particular reason.

Environment get dumped into container at /etc/environment. Potential security thread? It contains sensitive data.

Closes nils-wisiol/desec-internal#9.