### PR TITLE
On Update, Command Lord to Notify Master Immediately

### DIFF
--- a/api/desecapi/pdns.py
+++ b/api/desecapi/pdns.py
@@ -57,7 +57,7 @@ def _pdns_patch(url, body):
 
 def _pdns_get(url):
     r = requests.get(settings.NSLORD_PDNS_API + url, headers=headers_nslord)
-    if (r.status_code < 200 or r.status_code >= 500):
+    if r.status_code < 200 or r.status_code >= 500:
         raise Exception(r.text)
     return r
 

--- a/api/desecapi/tests/testdynupdateauthentication.py
+++ b/api/desecapi/tests/testdynupdateauthentication.py
@@ -32,6 +32,7 @@ class DynUpdateAuthenticationTests(APITestCase):
             httpretty.enable()
             httpretty.register_uri(httpretty.POST, settings.NSLORD_PDNS_API + '/zones')
             httpretty.register_uri(httpretty.PATCH, settings.NSLORD_PDNS_API + '/zones/' + self.domain + '.')
+            httpretty.register_uri(httpretty.PUT, settings.NSLORD_PDNS_API + '/zones/' + self.domain + './notify')
 
     def testSuccessfulAuthentication(self):
         response = self.client.get(self.url)


### PR DESCRIPTION
This decreases DNS update time at the nsmaster to approx. one 1 second.

Adopted unit tests, as most tests now need to access the last-but-one request to make their assertions.

Added a unit test to see if our code PUTs on the /notify endpoint of the pdns API.

Calling notify_zone immediately after creating a zone results in a 500 error at the pdns API. For discussion, see also #40.

Also, added a minor PEP style fix.