### PR TITLE
fix(db): init command violated unique constraint

### DIFF
--- a/dbapi/initdb.d/99-finish.sql
+++ b/dbapi/initdb.d/99-finish.sql
@@ -1,4 +1,4 @@
 -- Narrow down root logins
 INSTALL PLUGIN unix_socket SONAME 'auth_socket';
-UPDATE mysql.user SET Host = 'localhost', plugin = 'unix_socket' WHERE User = 'root';
+UPDATE mysql.user SET plugin = 'unix_socket' WHERE User = 'root' AND Host = 'localhost';
 FLUSH PRIVILEGES;

--- a/dbapi/initdb.d/99-finish.sql
+++ b/dbapi/initdb.d/99-finish.sql
@@ -1,4 +1,5 @@
 -- Narrow down root logins
 INSTALL PLUGIN unix_socket SONAME 'auth_socket';
+DELETE FROM mysql.user WHERE User = 'root' AND Host != 'localhost';
 UPDATE mysql.user SET plugin = 'unix_socket' WHERE User = 'root' AND Host = 'localhost';
 FLUSH PRIVILEGES;

--- a/dblord/initdb.d/99-finish.sql
+++ b/dblord/initdb.d/99-finish.sql
@@ -1,4 +1,4 @@
 -- Narrow down root logins
 INSTALL PLUGIN unix_socket SONAME 'auth_socket';
-UPDATE mysql.user SET Host = 'localhost', plugin = 'unix_socket' WHERE User = 'root';
+UPDATE mysql.user SET plugin = 'unix_socket' WHERE User = 'root' AND Host = 'localhost';
 FLUSH PRIVILEGES;

--- a/dblord/initdb.d/99-finish.sql
+++ b/dblord/initdb.d/99-finish.sql
@@ -1,4 +1,5 @@
 -- Narrow down root logins
 INSTALL PLUGIN unix_socket SONAME 'auth_socket';
+DELETE FROM mysql.user WHERE User = 'root' AND Host != 'localhost';
 UPDATE mysql.user SET plugin = 'unix_socket' WHERE User = 'root' AND Host = 'localhost';
 FLUSH PRIVILEGES;

--- a/dbmaster/initdb.d/99-finish.sql
+++ b/dbmaster/initdb.d/99-finish.sql
@@ -1,4 +1,4 @@
 -- Narrow down root logins
 INSTALL PLUGIN unix_socket SONAME 'auth_socket';
-UPDATE mysql.user SET Host = 'localhost', plugin = 'unix_socket' WHERE User = 'root';
+UPDATE mysql.user SET plugin = 'unix_socket' WHERE User = 'root' AND Host = 'localhost';
 FLUSH PRIVILEGES;

--- a/dbmaster/initdb.d/99-finish.sql
+++ b/dbmaster/initdb.d/99-finish.sql
@@ -1,4 +1,5 @@
 -- Narrow down root logins
 INSTALL PLUGIN unix_socket SONAME 'auth_socket';
+DELETE FROM mysql.user WHERE User = 'root' AND Host != 'localhost';
 UPDATE mysql.user SET plugin = 'unix_socket' WHERE User = 'root' AND Host = 'localhost';
 FLUSH PRIVILEGES;


### PR DESCRIPTION
There are four users in the database:
* generic root,
* local root
* desec
* desec_test

Hence, the old update command failed as it tried to update both root
users to be 'localhost'.