### PR TITLE
20171129 fix race condition

### DIFF
--- a/docs/domains.rst
+++ b/docs/domains.rst
@@ -41,7 +41,9 @@ Field details:
     Array with DNSSEC key information.  Each entry contains ``DNSKEY`` and
     ``DS`` record contents (the latter being computed from the former), and
     some extra information.  For delegation of DNSSEC-secured domains, the
-    domain registry needs to publish these ``DS`` records.
+    parent domain needs to publish these ``DS`` records.  (This usually
+    involves telling your registrar/registry about those records, and they
+    will publish them for you.)
 
     Notes:
 


### PR DESCRIPTION
This PR

- eliminates the race condition that occurs when users send multiple dynDNS IP update requests, by locking RRsets for update (previously, RRsets with same type/subname would have been attempted to be inserted twice, violating uniqueness)
- minimizes pdns interaction when records have not changed

It also contains a minor docs clarification (based on user feedback).