### PR TITLE
fix(api): reduce NSEC3 iterations to 127

### DIFF
--- a/api/desecapi/pdns.py
+++ b/api/desecapi/pdns.py
@@ -79,7 +79,7 @@ def create_zone(domain, nameservers):
 
     salt = '%016x' % random.randrange(16**16)
     payload = {'name': name, 'kind': 'MASTER', 'dnssec': True,
-               'nsec3param': '1 0 300 %s' % salt, 'nameservers': nameservers}
+               'nsec3param': '1 0 127 %s' % salt, 'nameservers': nameservers}
     _pdns_post('/zones', payload)
 
     notify_zone(domain)


### PR DESCRIPTION
RFC5155, Sec. 10.3 describes NSEC3 iteration count limits based on RSA
and DSA usage scenarios.  As we are using ECDSA 512-bit keys that are
roughly equivalent to a ~3100 RSA key, we picked an NSEC3 iteration
count that would be in the allowable range for such an RSA key.

However, practical experience [1] shows that many resolvers insist on
the maximum iteration count as applicable to a 512 RSA key.  As RFC5155
does not discuss ECDSA keys, they cannot really be blamed.  It is thus
recommendable to lower the count to <= 150.  127 seems like a good
value [2].

  [1]: https://www.mail-archive.com/dnsop@ietf.org/msg16148.html
  [2]: https://lists.dns-oarc.net/pipermail/dns-operations/2018-January/017174.html

Credits: Viktor Dukhovni