### PR TITLE
fix(token): URL-safe token encoding

### DIFF
--- a/api/desecapi/models.py
+++ b/api/desecapi/models.py
@@ -62,7 +62,7 @@ class Token(rest_framework.authtoken.models.Token):
         super().save(*args, **kwargs) # Call the "real" save() method.
 
     def generate_key(self):
-        return b64encode(urandom(21)).decode('utf-8')
+        return b64encode(urandom(21)).decode('utf-8').replace('/', '-').replace('=', '_').replace('+', '.')
 
     class Meta:
         abstract = False

--- a/api/desecapi/models.py
+++ b/api/desecapi/models.py
@@ -9,6 +9,7 @@ from django.core.validators import MinValueValidator
 from collections import OrderedDict
 import rest_framework.authtoken.models
 from time import time
+import random
 from os import urandom
 from base64 import b64encode
 
@@ -58,7 +59,7 @@ class Token(rest_framework.authtoken.models.Token):
 
     def save(self, *args, **kwargs):
         if not self.user_specific_id:
-            self.user_specific_id = int(time() * 100000)
+            self.user_specific_id = random.randrange(16**8)
         super().save(*args, **kwargs) # Call the "real" save() method.
 
     def generate_key(self):

--- a/api/desecapi/views.py
+++ b/api/desecapi/views.py
@@ -15,7 +15,7 @@ from rest_framework.renderers import StaticHTMLRenderer
 from dns import resolver
 from django.template.loader import get_template
 import desecapi.authentication as auth
-import base64
+import base64, binascii
 from desecapi import settings
 from rest_framework.exceptions import (
     APIException, MethodNotAllowed, PermissionDenied, ValidationError)
@@ -363,6 +363,8 @@ class DynDNS12Update(APIView):
             except IndexError:
                 pass
             except UnicodeDecodeError:
+                pass
+            except binascii.Error:
                 pass
 
             # 4. username parameter

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -225,9 +225,9 @@ to change in the future.
 
 Any token is generated from 168 bits of true randomness at the server. Guessing
 the token correctly is hence practically impossible. The value corresponds to 21
-bytes and is represented by 28 characters in Base64 encoding. That is, any token
-will only consist of characters ``A-Z``, ``a-z``, ``/``, and ``+``. (We do not
-have any ``=`` padding at the end because the string length is a multiple of 4.)
+bytes and is represented by 28 characters in Base64-like encoding. That is, any token
+will only consist of URL-safe characters ``A-Z``, ``a-z``, ``-``, and ``.``. (We do not
+have any padding at the end because the string length is a multiple of 4.)
 
 As all tokens are stored in plain text on the server, the user may not choose
 the token value individually to prevent re-using passwords as tokens at deSEC.

--- a/test/e2e/schemas.js
+++ b/test/e2e/schemas.js
@@ -61,4 +61,4 @@ exports.tokens = {
     items: exports.token
 };
 
-exports.TOKEN_REGEX = /^[A-Za-z0-9+/]{28}$/
+exports.TOKEN_REGEX = /^[A-Za-z0-9\.\-]{28}$/


### PR DESCRIPTION
With this changes, tokens generated in the future will be URL-safe. We send emails using tokens in URLs, so this change is urgent.