### PR TITLE
fix(api): migration referenced invalid field

### DIFF
--- a/api/desecapi/migrations/0022_domain_published.py
+++ b/api/desecapi/migrations/0022_domain_published.py
@@ -17,7 +17,7 @@ def forward_convert(apps, schema_editor):
 
         rrsets = RRset.objects.filter(domain=domain)
         created = rrsets.aggregate(Max('created'))['created__max']
-        published = rrsets.aggregate(Max('published'))['published__max'] or created
+        published = rrsets.aggregate(Max('updated'))['updated__max'] or created
         # .update() operates on a queryset (not on a Model instance)
         Domain.objects.filter(pk=domain.pk).update(published=max(created, published))
 


### PR DESCRIPTION
This did not show up in tests because during testing because the issue
was with migration the existing data rows.  However, migrations are
applied to an empty database, so the buggy code was in fact not tested.