### PR TITLE
Introduce API Versions and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 deSEC Stack
-=====
+===========
 
 This is a docker-compose application providing the basic stack for deSEC name services. It consists of
 
@@ -11,7 +11,7 @@ This is a docker-compose application providing the basic stack for deSEC name se
 
 
 Requirements
------
+------------
 
 Although most configuration is contained in this repository, some external dependencies need to be met before the application can be run. Dependencies are:
 
@@ -61,7 +61,7 @@ Running the standard stack will also fire up an instance of the `www` proxy serv
 
 
 How to Run
------
+----------
 
 Development:
 
@@ -73,13 +73,26 @@ Production:
 
 
 Storage
----
+-------
 All important data is stored in the databases managed by the `db*` containers. They use Docker volumes which, by default, reside in `/var/lib/docker/volumes/desecstack_{dbapi,dblord,dbmaster}_mysql`.
 This is the location you will want to back up. (Be sure to follow standard MySQL backup practices, i.e. make sure things are consistent.)
 
 
+API Versions and Roadmap
+------------------------
+
+deSEC currently maintains the following API versions:
+
+API Version | URL Prefix | Status                                   | Support Ends
+----------- | ---------- | ---------------------------------------- | ------------
+Version 1   | `/api/v1/` |  unstable, stable release exp. June 2019 | earliest 6 months after v2 is declared stable
+Version 2   | `/api/v2/` |  unstable
+
+You can find our documentation for all API versions at https://desec.readthedocs.io/. (Select the version of interest in the navigation bar.)
+
+
 Notes on IPv6
------
+-------------
 
 This stack is IPv6-capable. Caveats:
 

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -88,6 +88,8 @@ REST_FRAMEWORK = {
     ),
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
     'EXCEPTION_HANDLER': 'desecapi.exception_handlers.handle_db_unavailable',
+    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.NamespaceVersioning',
+    'ALLOWED_VERSIONS': ['v1', 'v2'],
 }
 
 # user management configuration

--- a/api/api/urls.py
+++ b/api/api/urls.py
@@ -1,38 +1,61 @@
-from django.conf.urls import include, url
-from desecapi import views
-from djoser.views import UserView
-from rest_framework.routers import SimpleRouter
+from django.urls import include, path
 
-tokens_router = SimpleRouter()
-tokens_router.register(r'', views.TokenViewSet, base_name='token')
 
-auth_urls = [
-    url(r'^users/create/$', views.UserCreateView.as_view(), name='user-create'),  # deprecated
-    url(r'^token/create/$', views.TokenCreateView.as_view(), name='token-create'),  # deprecated
-    url(r'^token/destroy/$', views.TokenDestroyView.as_view(), name='token-destroy'),  # deprecated
-    url(r'^users/$', views.UserCreateView.as_view(), name='register'),
-    url(r'^token/login/$', views.TokenCreateView.as_view(), name='login'),
-    url(r'^token/logout/$', views.TokenDestroyView.as_view(), name='logout'),
-    url(r'^tokens/', include(tokens_router.urls)),
-    url(r'^me/?$', UserView.as_view(), name='user'),
-    url(r'^', include('djoser.urls.authtoken')),
-]
+#
+# On Reversing URLs
+# =================
+#
+# Recommended Usage:
+# Always use rest_framework.reverse.reverse, do not directly use django.urls.reverse.
+# If a request object r is available, use reverse(name, request=r). With the name as defined
+# in desecapi.urls.v1 or desecapi.urls.v2. It will return an URL maintaining the currently requested API version.
+# If there is no request object available, e.g. in commands, a mock object can be constructed
+# carrying all information that is necessary to construct a full URL:
+#
+#         from django.test import RequestFactory
+#         from rest_framework.versioning import NamespaceVersioning
+#         from api import settings
+#
+#         r = RequestFactory().request(HTTP_HOST=settings.ALLOWED_HOSTS[0])
+#         r.version = 'v1'
+#         r.versioning_scheme = NamespaceVersioning()
+#
+# Also note in this context settings.REST_FRAMEWORK['ALLOWED_VERSIONS'] and
+# settings.REST_FRAMEWORK['DEFAULT_VERSIONING_CLASS']. (The latter is of type string.)
+#
+# Advanced Usage:
+# Prefix the name of any path with 'desecapi' to get the default version,
+# or prefix the name of any path with the desired namespace, e.g. 'v1:root'.
+# In this case, the version information of the request will be ignored and
+# providing a request object is optional. However, if no request object is provided,
+# only a relative URL can be generated.
+#
+# Examples:
+# The examples refer to the version used by the client to connect as the REQUESTED version,
+# the version specified by the first argument to reverse as the SPECIFIED version, and to the
+# version defined as default (see below) as the DEFAULT version.
+#
+#         reverse('root', request) -> absolute URL, e.g. https://.../api/v1/, with the REQUESTED version
+#         reverse('root') -> django.urls.exceptions.NoReverseMatch
+#         reverse('desecapi:root') -> relative URL, e.g. api/v1/, with the DEFAULT version
+#         reverse('v2:root') -> relative URL, e.g. api/v2/, with the SPECIFIED version
+#         reverse('v2:root', request) -> absolute URL, e.g. https://.../api/v2/, with the SPECIFIED version
+#         reverse('desecapi:root', request) -> absolute URL, e.g. https://.../api/v1/, with the DEFAULT version
+#         reverse('v1:root', request) -> absolute URL, e.g. https://.../api/v1/, with the SPECIFIED version
+#
+# See Also:
+# https://github.com/encode/django-rest-framework/issues/5659
+# https://github.com/encode/django-rest-framework/issues/3825
+#
+# Note that from the client's perspective, there is no default version: each request needs to
+# specify the version in the request URL.
+#
 
-api_urls = [
-    url(r'^$', views.Root.as_view(), name='root'),
-    url(r'^domains/$', views.DomainList.as_view(), name='domain-list'),
-    url(r'^domains/(?P<name>[a-zA-Z\.\-_0-9]+)/$', views.DomainDetail.as_view(), name='domain-detail'),
-    url(r'^domains/(?P<name>[a-zA-Z\.\-_0-9]+)/rrsets/$', views.RRsetList.as_view(), name='rrsets'),
-    url(r'^domains/(?P<name>[a-zA-Z\.\-_0-9]+)/rrsets/(?P<subname>(\*)?[a-zA-Z\.\-_0-9=]*)\.\.\./(?P<type>[A-Z][A-Z0-9]*)/$', views.RRsetDetail.as_view(), name='rrset'),
-    url(r'^domains/(?P<name>[a-zA-Z\.\-_0-9]+)/rrsets/(?P<subname>[*@]|[a-zA-Z\.\-_0-9=]+)/(?P<type>[A-Z][A-Z0-9]*)/$', views.RRsetDetail.as_view(), name='rrset@'),
-    url(r'^dns$', views.DnsQuery.as_view(), name='dns-query'),
-    url(r'^dyndns/update$', views.DynDNS12Update.as_view(), name='dyndns12update'),
-    url(r'^donation/', views.DonationList.as_view(), name='donation'),
-    url(r'^unlock/user/(?P<email>.+)$', views.unlock, name='unlock/byEmail'),
-    url(r'^unlock/done', views.unlock_done, name='unlock/done'),
-]
-
+# IMPORTANT: specify default version as the last element in the list
+# if no other information is available, the last-specified version will be used as default for reversing URLs
 urlpatterns = [
-    url(r'^api/v1/auth/', include(auth_urls)),
-    url(r'^api/v1/', include(api_urls)),
+    # other available versions in no particular order
+    path('api/v2/', include('desecapi.urls.version_2', namespace='v2')),
+    # the DEFAULT version
+    path('api/v1/', include('desecapi.urls.version_1', namespace='v1')),
 ]

--- a/api/desecapi/authentication.py
+++ b/api/desecapi/authentication.py
@@ -1,7 +1,6 @@
-from __future__ import unicode_literals
 import base64
 from rest_framework import exceptions, HTTP_HEADER_ENCODING
-from rest_framework.authentication import BaseAuthentication, get_authorization_header, authenticate
+from rest_framework.authentication import BaseAuthentication, get_authorization_header
 from desecapi.models import Token
 from rest_framework.authentication import TokenAuthentication as RestFrameworkTokenAuthentication
 

--- a/api/desecapi/management/commands/sync-from-pdns.py
+++ b/api/desecapi/management/commands/sync-from-pdns.py
@@ -1,5 +1,5 @@
 from django.core.management import BaseCommand, CommandError
-from desecapi.models import Domain, RRset
+from desecapi.models import Domain
 
 
 class Command(BaseCommand):

--- a/api/desecapi/tests/testdonations.py
+++ b/api/desecapi/tests/testdonations.py
@@ -1,8 +1,6 @@
-# coding: utf-8
 from rest_framework.reverse import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
-from desecapi.tests.utils import utils
 from django.core import mail
 
 

--- a/api/desecapi/tests/testdonations.py
+++ b/api/desecapi/tests/testdonations.py
@@ -1,35 +1,31 @@
 # coding: utf-8
-from django.urls import reverse
+from rest_framework.reverse import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
-from .utils import utils
-from django.db import transaction
-from desecapi.models import Domain
+from desecapi.tests.utils import utils
 from django.core import mail
-import httpretty
-from django.conf import settings
 
 
 class UnsuccessfulDonationTests(APITestCase):
     def testExpectUnauthorizedOnGet(self):
-        url = reverse('donation')
+        url = reverse('v1:donation')
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def testExpectUnauthorizedOnPut(self):
-        url = reverse('donation')
+        url = reverse('v1:donation')
         response = self.client.put(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
     def testExpectUnauthorizedOnDelete(self):
-        url = reverse('donation')
+        url = reverse('v1:donation')
         response = self.client.delete(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
 class SuccessfulDonationTests(APITestCase):
     def testCanPostDonations(self):
-        url = reverse('donation')
+        url = reverse('v1:donation')
         data = \
             {
                 'name': 'Komplizierter Vörnämü-ßßß 马大为',

--- a/api/desecapi/tests/testdynupdateauthentication.py
+++ b/api/desecapi/tests/testdynupdateauthentication.py
@@ -1,7 +1,7 @@
-from django.urls import reverse
+from rest_framework.reverse import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
-from .utils import utils
+from desecapi.tests.utils import utils
 import httpretty
 import base64
 from django.conf import settings
@@ -20,11 +20,11 @@ class DynUpdateAuthenticationTests(APITestCase):
             self.user = utils.createUser(self.username, self.password)
             self.token = utils.createToken(user=self.user)
             self.setCredentials(self.username, self.password)
-            self.url = reverse('dyndns12update')
+            self.url = reverse('v1:dyndns12update')
 
             self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
             self.domain = utils.generateDynDomainname()
-            url = reverse('domain-list')
+            url = reverse('v1:domain-list')
             data = {'name': self.domain}
             response = self.client.post(url, data)
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/api/desecapi/tests/testprivacychores.py
+++ b/api/desecapi/tests/testprivacychores.py
@@ -1,7 +1,7 @@
 from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
-from desecapi.models import User, MyUserManager
+from desecapi.models import User
 from .utils import utils
 from api import settings
 from datetime import timedelta

--- a/api/desecapi/tests/testregistration.py
+++ b/api/desecapi/tests/testregistration.py
@@ -1,7 +1,10 @@
-from django.urls import reverse
+from django.test import RequestFactory
+from rest_framework.reverse import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
-from .utils import utils
+from rest_framework.versioning import NamespaceVersioning
+
+from desecapi.tests.utils import utils
 from desecapi import models
 from datetime import timedelta
 from django.utils import timezone
@@ -13,7 +16,7 @@ from api import settings
 class RegistrationTest(APITestCase):
 
     def test_registration_successful(self):
-        url = reverse('register')
+        url = reverse('v1:register')
         data = {'email': utils.generateUsername(), 'password': utils.generateRandomString(size=12)}
         response = self.client.post(url, data, REMOTE_ADDR="1.3.3.7")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -24,7 +27,7 @@ class RegistrationTest(APITestCase):
     def test_multiple_registration_locked_same_ip_short_time(self):
         outboxlen = len(mail.outbox)
 
-        url = reverse('register')
+        url = reverse('v1:register')
         data = {'email': utils.generateUsername(),
                 'password': utils.generateRandomString(size=12), 'dyn': True}
         response = self.client.post(url, data, REMOTE_ADDR="1.3.3.7")
@@ -36,7 +39,7 @@ class RegistrationTest(APITestCase):
 
         self.assertEqual(len(mail.outbox), outboxlen)
 
-        url = reverse('register')
+        url = reverse('v1:register')
         data = {'email': utils.generateUsername(),
                 'password': utils.generateRandomString(size=12), 'dyn': True}
         response = self.client.post(url, data, REMOTE_ADDR="1.3.3.7")
@@ -48,7 +51,7 @@ class RegistrationTest(APITestCase):
 
         self.assertEqual(len(mail.outbox), outboxlen + 1)
 
-        url = reverse('register')
+        url = reverse('v1:register')
         data = {'email': utils.generateUsername(),
                 'password': utils.generateRandomString(size=12), 'dyn': True}
         response = self.client.post(url, data, REMOTE_ADDR="1.3.3.7")
@@ -61,7 +64,7 @@ class RegistrationTest(APITestCase):
         self.assertEqual(len(mail.outbox), outboxlen + 2)
 
     def test_multiple_registration_not_locked_different_ip(self):
-        url = reverse('register')
+        url = reverse('v1:register')
         data = {'email': utils.generateUsername(), 'password': utils.generateRandomString(size=12)}
         response = self.client.post(url, data, REMOTE_ADDR="1.3.3.8")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -70,7 +73,7 @@ class RegistrationTest(APITestCase):
         self.assertEqual(user.registration_remote_ip, "1.3.3.8")
         self.assertIsNone(user.locked)
 
-        url = reverse('register')
+        url = reverse('v1:register')
         data = {'email': utils.generateUsername(), 'password': utils.generateRandomString(size=12)}
         response = self.client.post(url, data, REMOTE_ADDR="1.3.3.9")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -80,7 +83,7 @@ class RegistrationTest(APITestCase):
         self.assertIsNone(user.locked)
 
     def test_multiple_registration_not_locked_same_ip_long_time(self):
-        url = reverse('register')
+        url = reverse('v1:register')
         data = {'email': utils.generateUsername(), 'password': utils.generateRandomString(size=12)}
         response = self.client.post(url, data, REMOTE_ADDR="1.3.3.10")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -93,7 +96,7 @@ class RegistrationTest(APITestCase):
         user.created = timezone.now() - timedelta(hours=settings.ABUSE_BY_REMOTE_IP_PERIOD_HRS+1)
         user.save()
 
-        url = reverse('register')
+        url = reverse('v1:register')
         data = {'email': utils.generateUsername(), 'password': utils.generateRandomString(size=12)}
         response = self.client.post(url, data, REMOTE_ADDR="1.3.3.10")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -105,20 +108,23 @@ class RegistrationTest(APITestCase):
     def test_send_captcha_email_manually(self):
         outboxlen = len(mail.outbox)
 
-        url = reverse('register')
+        url = reverse('v1:register')
         data = {'email': utils.generateUsername(),
                 'password': utils.generateRandomString(size=12), 'dyn': True}
         response = self.client.post(url, data, REMOTE_ADDR="1.3.3.10")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         user = models.User.objects.get(email=data['email'])
-        send_account_lock_email(None, user)
+        r = RequestFactory().request(HTTP_HOST=settings.ALLOWED_HOSTS[0])
+        r.version = 'v1'
+        r.versioning_scheme = NamespaceVersioning()
+        send_account_lock_email(r, user)
 
         self.assertEqual(len(mail.outbox), outboxlen+1)
 
     def test_multiple_registration_locked_same_email_host(self):
         outboxlen = len(mail.outbox)
 
-        url = reverse('register')
+        url = reverse('v1:register')
         for i in range(settings.ABUSE_BY_EMAIL_HOSTNAME_LIMIT):
             data = {
                 'email': utils.generateRandomString() + '@test-same-email.desec.io',
@@ -133,7 +139,7 @@ class RegistrationTest(APITestCase):
 
         self.assertEqual(len(mail.outbox), outboxlen)
 
-        url = reverse('register')
+        url = reverse('v1:register')
         data = {
             'email': utils.generateRandomString() + '@test-same-email.desec.io',
             'password': utils.generateRandomString(size=12),
@@ -150,7 +156,7 @@ class RegistrationTest(APITestCase):
     def test_multiple_registration_not_locked_same_email_host_long_time(self):
         outboxlen = len(mail.outbox)
 
-        url = reverse('register')
+        url = reverse('v1:register')
         for i in range(settings.ABUSE_BY_EMAIL_HOSTNAME_LIMIT):
             data = {
                 'email': utils.generateRandomString() + '@test-same-email-1.desec.io',
@@ -170,7 +176,7 @@ class RegistrationTest(APITestCase):
 
         self.assertEqual(len(mail.outbox), outboxlen)
 
-        url = reverse('register')
+        url = reverse('v1:register')
         data = {
             'email': utils.generateRandomString() + '@test-same-email-1.desec.io',
             'password': utils.generateRandomString(size=12),
@@ -187,7 +193,7 @@ class RegistrationTest(APITestCase):
     def test_token_email(self):
         outboxlen = len(mail.outbox)
 
-        url = reverse('register')
+        url = reverse('v1:register')
         data = {
             'email': utils.generateRandomString() + '@test-same-email.desec.io',
             'password': utils.generateRandomString(size=12),

--- a/api/desecapi/urls/version_1.py
+++ b/api/desecapi/urls/version_1.py
@@ -1,0 +1,61 @@
+from django.urls import include, path, re_path
+from djoser.views import UserView
+from rest_framework.routers import SimpleRouter
+
+from desecapi import views
+
+
+tokens_router = SimpleRouter()
+tokens_router.register(r'', views.TokenViewSet, base_name='token')
+
+auth_urls = [
+    # Old user management
+    # TODO deprecated, remove
+    path('users/create/', views.UserCreateView.as_view(), name='user-create'),  # deprecated
+    path('token/create/', views.TokenCreateView.as_view(), name='token-create'),  # deprecated
+    path('token/destroy/', views.TokenDestroyView.as_view(), name='token-destroy'),  # deprecated
+
+    # New user management
+    path('users/', views.UserCreateView.as_view(), name='register'),
+
+    # Token management
+    path('token/login/', views.TokenCreateView.as_view(), name='login'),
+    path('token/logout/', views.TokenDestroyView.as_view(), name='logout'),
+    path('', include('djoser.urls.authtoken')),  # note: this is partially overwritten by the two lines above
+    path('tokens/', include(tokens_router.urls)),
+
+    # User home
+    path('me/', UserView.as_view(), name='user'),
+]
+
+api_urls = [
+    # API home
+    path('', views.Root.as_view(), name='root'),
+
+    # Domain and RRSet endpoints
+    path('domains/', views.DomainList.as_view(), name='domain-list'),
+    re_path(r'^domains/(?P<name>[a-zA-Z\.\-_0-9]+)/$', views.DomainDetail.as_view(), name='domain-detail'),
+    re_path(r'^domains/(?P<name>[a-zA-Z\.\-_0-9]+)/rrsets/$', views.RRsetList.as_view(), name='rrsets'),
+    re_path(r'^domains/(?P<name>[a-zA-Z\.\-_0-9]+)/rrsets/(?P<subname>(\*)?[a-zA-Z\.\-_0-9=]*)\.\.\./(?P<type>[A-Z][A-Z0-9]*)/$', views.RRsetDetail.as_view(), name='rrset'),
+    re_path(r'^domains/(?P<name>[a-zA-Z\.\-_0-9]+)/rrsets/(?P<subname>[*@]|[a-zA-Z\.\-_0-9=]+)/(?P<type>[A-Z][A-Z0-9]*)/$', views.RRsetDetail.as_view(), name='rrset@'),
+
+    # DNS query endpoint
+    # TODO remove?
+    path('dns', views.DnsQuery.as_view(), name='dns-query'),
+
+    # DynDNS update endpoint
+    path('dyndns/update', views.DynDNS12Update.as_view(), name='dyndns12update'),
+
+    # Donation endpoints
+    path('donation/', views.DonationList.as_view(), name='donation'),
+
+    # Unlock endpoints
+    path('unlock/user/<email>', views.unlock, name='unlock/byEmail'),
+    path('unlock/done', views.unlock_done, name='unlock/done'),
+]
+
+app_name = 'desecapi'
+urlpatterns = [
+    path('auth/', include(auth_urls)),
+    path('', include(api_urls)),
+]

--- a/api/desecapi/urls/version_2.py
+++ b/api/desecapi/urls/version_2.py
@@ -1,0 +1,4 @@
+from desecapi.urls.version_1 import urlpatterns as version_1
+
+app_name = 'desecapi'
+urlpatterns = version_1

--- a/api/desecapi/views.py
+++ b/api/desecapi/views.py
@@ -297,14 +297,14 @@ class Root(APIView):
     def get(self, request, format=None):
         if self.request.user and self.request.user.is_authenticated:
             return Response({
-                'domains': reverse('domain-list'),
-                'user': reverse('user'),
-                'logout': reverse('token-destroy'),  # TODO change interface to token-destroy, too?
+                'domains': reverse('domain-list', request=request),
+                'user': reverse('user', request=request),
+                'logout': reverse('token-destroy', request=request),  # TODO change interface to token-destroy, too?
             })
         else:
             return Response({
-                'login': reverse('token-create', request=request, format=format),  # TODO change interface to token-create, too?
-                'register': reverse('register', request=request, format=format),
+                'login': reverse('token-create', request=request),
+                'register': reverse('register', request=request),
             })
 
 
@@ -546,7 +546,7 @@ def unlock(request, email):
                 # fail silently, so people can't probe registered addresses
                 pass
 
-            return HttpResponseRedirect(reverse('unlock/done'))
+            return HttpResponseRedirect(reverse('unlock/done', request=request))
 
     # if a GET (or any other method) we'll create a blank form
     else:

--- a/api/entrypoint-tests.sh
+++ b/api/entrypoint-tests.sh
@@ -8,4 +8,5 @@ echo "waiting for dependencies ..."
 /root/cronhook/start-cron.sh &
 
 echo Starting API tests ...
-python3 manage.py test -v 3 --noinput
+coverage run --source='.' manage.py test -v 3 --noinput
+coverage report

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,3 +8,4 @@ requests~=2.21.0
 uwsgi~=2.0.0
 django-nocaptcha-recaptcha==0.0.20  # updated manually
 djangorestframework-bulk~=0.2.0
+coverage~=4.5.3

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,7 @@
 .. include:: domains.rst
 .. include:: rrsets.rst
 .. include:: endpoint-reference.rst
+.. include:: lifecycle.rst
 
 Getting Help
 ------------

--- a/docs/lifecycle.rst
+++ b/docs/lifecycle.rst
@@ -1,0 +1,39 @@
+API Versions and Lifecycle
+--------------------------
+
+To enable users to build reliable tools on top of the deSEC API, we
+maintain stable versions of the API for extended periods of time.
+
+Each API version will advance through the API version lifecycle,
+starting from `unstable` and proceeding to `stable`, `deprecated`,
+and, finally, to `historical`.
+
+Check out the `current status of the API versions`_ to make sure you
+are using the latest stable API whenever using our service in
+production.
+
+.. _current status of the API versions: https://github.com/desec-io/desec-stack/#api-versions-and-road-map
+
+**Unstable API versions** are currently under development and may
+change without prior notice, but we promise to keep an eye on users
+affected by incompatible changes.
+
+For all **stable API versions**, we guarantee that
+
+1. it will be maintained at least until the end of the given support
+   period,
+
+2. there will be no incompatible changes made to the interface, unless
+   security vulnerabilities make such changes inevitable,
+
+3. users will be warned before the end of the support period.
+
+**Deprecated API versions** are going to be disabled in the future.
+Users will be notified via email and are encouraged to migrate to the
+next stable version as soon as possible. For this purpose, a migration
+advisory will be provided. After the support period is over, deprecated
+API versions may be disabled without further warning and transition to
+historical state.
+
+**Historical API versions** are permanently disabled and cannot be used.
+

--- a/test/e2e/schemas.js
+++ b/test/e2e/schemas.js
@@ -1,5 +1,12 @@
 // For format specs, see https://json-schema.org/latest/json-schema-validation.html#rfc.section.7.3
 
+exports.rootNoLogin = {
+    properties: {
+        login: { type: "string" },
+        register: { type: "string" },
+    }
+};
+
 exports.user = {
     properties: {
         dyn: { type: "boolean" },


### PR DESCRIPTION
This PR introduces API Version 2, that is a currently an alias for Version 1 and shall later be a stable copy of Version 1. Along the way, this PR cleans up the API definitions and re-organizes them. It also includes end-user documentation for API versioning.

Closes #137 