### PR TITLE
fix(api): recover OperationalError information when sending 503 reponse

### DIFF
--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -77,11 +77,14 @@ TIME_ZONE = 'UTC'
 USE_TZ = True
 
 REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': (
-        'desecapi.authentication.TokenAuthentication',
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
     ),
     'DEFAULT_PARSER_CLASSES': (
         'rest_framework.parsers.JSONParser',
+    ),
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'desecapi.authentication.TokenAuthentication',
     ),
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
     'EXCEPTION_HANDLER': 'desecapi.exception_handlers.handle_db_unavailable',

--- a/api/desecapi/exception_handlers.py
+++ b/api/desecapi/exception_handlers.py
@@ -1,7 +1,8 @@
 from django.db.utils import OperationalError
 from rest_framework import status
 from rest_framework.response import Response
-from rest_framework.views import exception_handler, set_rollback
+from rest_framework.views import exception_handler
+import logging
 
 
 def handle_db_unavailable(exc, context):
@@ -21,6 +22,9 @@ def handle_db_unavailable(exc, context):
                 2009,  # Wrong host info
                 2026,  # SSL connection error
         ):
+            logging.getLogger('django.request').error('OperationalError Supplementary Information',
+                                                      exc_info=exc, stack_info=False)
+
             # Gracefully let clients know that we cannot connect to the database
             data = {'detail': 'Please try again later.'}
 


### PR DESCRIPTION
Since 7c1b70c4dcb79acdc3b3d86ae772630d4f56f837 we convert OperationalError
exceptions into 503 responses. This does not inhibit the error email being
sent to the admins, but the exception details are replaced by the generic
statement "Service Unavailable: {path}".

At this point, the exception has been turned into a 503 response that raises
a generic 5xx exception leading to the email. The details of the original
exception are gone at that point. However, as admins we'd like to receive
these details.

A nice solution would be to raise a 503 exception that carries the details
without leaking them in the response. However, there is no Django exception
available for the 503 use case.

This commit thus simply adds a supplementary email that reporting the
original error. The effort to avoid the other email seemed unreasonable.

closes #141