### PR TITLE
Upgrade PowerDNS, Django, Djoser, and Some Others

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,12 @@
+# python virtualenv
 .env
+api/venv
+
+# IDE files
 .idea
+
+# development helper scripts
+/*.sh
+
+# local certificates
+/certs/

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,11 +1,10 @@
-Django~=2.1.5
+Django~=2.2.0
 mysqlclient~=1.4.0
 djangorestframework~=3.7.0  # djangorestframework-bulk 0.2.0 stops us from upgrading to 3.8
-djoser~=1.4.0
-dnspython~=1.15.0
+djoser~=1.5.1
+dnspython~=1.16.0
 httpretty~=0.9.0
 requests~=2.21.0
 uwsgi~=2.0.0
 django-nocaptcha-recaptcha==0.0.20  # updated manually
-sqlparse~=0.2.0
 djangorestframework-bulk~=0.2.0


### PR DESCRIPTION
`djangorestframework-bulk` still stops us from upgrading `djangorestframework`. We are currently using 3.7 (12/2017), newest version is 3.9 (03/2019). We should consider replacing it with some other solution or forking it to maintain it ourselves.