### PR TITLE
fix(api): reversing failed due to missing info on the request

### DIFF
--- a/api/desecapi/views.py
+++ b/api/desecapi/views.py
@@ -545,7 +545,7 @@ def unlock(request, email):
                 # fail silently, so people can't probe registered addresses
                 pass
 
-            return HttpResponseRedirect(reverse('unlock/done', request=request))
+            return HttpResponseRedirect(reverse('v1:unlock/done', request=request))  # TODO remove dependency on v1
 
     # if a GET (or any other method) we'll create a blank form
     else:


### PR DESCRIPTION
As the request was not processed by rest_framework, there was no
versioning_scheme information present; reversing hence failed and
caused a 500 error after the unlock was successfully commited to
the database.