### PR TITLE
fix(tests): typo in RRsets filter

### DIFF
--- a/api/desecapi/tests/testrrsets.py
+++ b/api/desecapi/tests/testrrsets.py
@@ -110,7 +110,7 @@ class AuthenticatedRRSetTestCase(DomainOwnerTestCase):
     @staticmethod
     def _filter_rr_sets(rr_sets, **kwargs):
         return [
-            rr_sets for rr_set in rr_sets
+            rr_set for rr_set in rr_sets
             if reduce(operator.and_, [rr_set.get(key, None) == value for key, value in kwargs.items()])
         ]
 


### PR DESCRIPTION
I found a typo in the RRsets filter used in tests. I appears to have been without consequence; I wonder how that can be? You can probably figure it out quicker as it's your code.