### PR TITLE
Code Style Improvements

### DIFF
--- a/api/api/settings_quick_test.py
+++ b/api/api/settings_quick_test.py
@@ -1,5 +1,6 @@
 from api.settings import *
 
+# noinspection PyUnresolvedReferences
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',

--- a/api/desecapi/authentication.py
+++ b/api/desecapi/authentication.py
@@ -48,7 +48,7 @@ class BasicTokenAuthentication(BaseAuthentication):
         try:
             user, key = base64.b64decode(basic).decode(HTTP_HEADER_ENCODING).split(':')
             token = self.model.objects.get(key=key)
-        except:
+        except Exception:
             raise exceptions.AuthenticationFailed(invalid_token_message)
 
         if not token.user.is_active:
@@ -72,16 +72,16 @@ class URLParamAuthentication(BaseAuthentication):
         using URL parameters.  Otherwise returns `None`.
         """
 
-        if not 'username' in request.query_params:
+        if 'username' not in request.query_params:
             msg = 'No username URL parameter provided.'
             raise exceptions.AuthenticationFailed(msg)
-        if not 'password' in request.query_params:
+        if 'password' not in request.query_params:
             msg = 'No password URL parameter provided.'
             raise exceptions.AuthenticationFailed(msg)
 
         return self.authenticate_credentials(request.query_params['username'], request.query_params['password'])
 
-    def authenticate_credentials(self, userid, key):
+    def authenticate_credentials(self, _, key):
         try:
             token = self.model.objects.get(key=key)
         except self.model.DoesNotExist:

--- a/api/desecapi/emails.py
+++ b/api/desecapi/emails.py
@@ -2,6 +2,7 @@ from django.template.loader import get_template
 from django.core.mail import EmailMessage
 from rest_framework.reverse import reverse
 
+
 def send_account_lock_email(request, user):
     content_tmpl = get_template('emails/captcha/content.txt')
     subject_tmpl = get_template('emails/captcha/subject.txt')
@@ -15,6 +16,7 @@ def send_account_lock_email(request, user):
                          from_tmpl.render(context),
                          [user.email])
     email.send()
+
 
 def send_token_email(context, user):
     content_tmpl = get_template('emails/user-token/content.txt')

--- a/api/desecapi/exceptions.py
+++ b/api/desecapi/exceptions.py
@@ -1,5 +1,7 @@
-from rest_framework.exceptions import APIException
 import json
+from json import JSONDecodeError
+
+from rest_framework.exceptions import APIException
 
 
 class PdnsException(APIException):
@@ -11,5 +13,5 @@ class PdnsException(APIException):
         else:
             try:
                 self.detail = json.loads(response.text)['error']
-            except:
+            except (JSONDecodeError, KeyError):
                 self.detail = response.text

--- a/api/desecapi/management/commands/privacy-chores.py
+++ b/api/desecapi/management/commands/privacy-chores.py
@@ -1,8 +1,10 @@
-from django.core.management import BaseCommand
-from desecapi.models import User
-from api import settings
-from django.utils import timezone
 from datetime import timedelta
+
+from django.core.management import BaseCommand
+from django.utils import timezone
+
+from api import settings
+from desecapi.models import User
 
 
 class Command(BaseCommand):

--- a/api/desecapi/management/commands/sync-from-pdns.py
+++ b/api/desecapi/management/commands/sync-from-pdns.py
@@ -1,4 +1,5 @@
 from django.core.management import BaseCommand, CommandError
+
 from desecapi.models import Domain
 
 
@@ -6,7 +7,8 @@ class Command(BaseCommand):
     help = 'Import authoritative data from pdns, making the local database consistent with pdns.'
 
     def add_arguments(self, parser):
-        parser.add_argument('domain-name', nargs='*', help='Domain name to import. If omitted, will import all domains that are known locally.')
+        parser.add_argument('domain-name', nargs='*',
+                            help='Domain name to import. If omitted, will import all domains that are known locally.')
 
     def handle(self, *args, **options):
         domains = Domain.objects.all()

--- a/api/desecapi/pdns.py
+++ b/api/desecapi/pdns.py
@@ -1,9 +1,10 @@
-import requests
 import json
 import random
+
+import requests
+
 from api import settings
 from desecapi.exceptions import PdnsException
-
 
 headers_nslord = {
     'Accept': 'application/json',
@@ -40,7 +41,7 @@ def _pdns_delete_zone(domain):
         else:
             raise PdnsException(r2)
 
-    return (r1, r2)
+    return r1, r2
 
 
 def _pdns_request(method, path, body=None, acceptable_range=range(200, 300)):
@@ -126,13 +127,19 @@ def get_rrset_datas(domain):
 
 
 def set_rrsets(domain, rrsets, notify=True):
-    data = {'rrsets':
-        [{'name': rrset.name, 'type': rrset.type, 'ttl': rrset.ttl,
-          'changetype': 'REPLACE',
-          'records': [{'content': record.content, 'disabled': False}
-                      for record in rrset.records.all()]
-          }
-         for rrset in rrsets]
+    data = {
+        'rrsets':
+        [
+            {
+                'name': rrset.name, 'type': rrset.type, 'ttl': rrset.ttl,
+                'changetype': 'REPLACE',
+                'records': [
+                    {'content': record.content, 'disabled': False}
+                    for record in rrset.records.all()
+                ]
+            }
+            for rrset in rrsets
+        ]
     }
     _pdns_patch('/zones/' + domain.pdns_id, data)
 

--- a/api/desecapi/templatetags/sepa_extras.py
+++ b/api/desecapi/templatetags/sepa_extras.py
@@ -1,14 +1,17 @@
-from django import template
-import unicodedata
 import re
+import unicodedata
+
+from django import template
 
 register = template.Library()
+
 
 def clean(value):
     """Replaces non-ascii characters with their closest ascii
        representation and then removes everything but [A-Za-z0-9 ]"""
     normalized = unicodedata.normalize('NFKD', value)
-    cleaned = re.sub(r'[^A-Za-z0-9 ]','',normalized)
+    cleaned = re.sub(r'[^A-Za-z0-9 ]', '', normalized)
     return cleaned
+
 
 register.filter('clean', clean)

--- a/api/desecapi/tests/base.py
+++ b/api/desecapi/tests/base.py
@@ -301,7 +301,6 @@ class MockPDNSTestCase(APITestCase):
         request.pop('status')
         return request
 
-
     @classmethod
     def request_pdns_zone_retrieve(cls, name=None):
         return {
@@ -645,6 +644,13 @@ class DomainOwnerTestCase(DesecTestCase):
     DYN = False
     NUM_OWNED_DOMAINS = 2
     NUM_OTHER_DOMAINS = 20
+
+    owner = None
+    my_domains = None
+    other_domains = None
+    my_domain = None
+    other_domain = None
+    token = None
 
     @classmethod
     def setUpTestDataWithPdns(cls):

--- a/api/desecapi/tests/base.py
+++ b/api/desecapi/tests/base.py
@@ -404,8 +404,8 @@ class MockPDNSTestCase(APITestCase):
         return AssertRequestsContextManager(
             test_case=self,
             expected_requests=[
-                self.request_pdns_zone_delete(ns='LORD', name=None),
-                self.request_pdns_zone_delete(ns='MASTER', name=None),
+                self.request_pdns_zone_delete(ns='LORD', name=name),
+                self.request_pdns_zone_delete(ns='MASTER', name=name),
             ],
         )
 

--- a/api/desecapi/tests/testdomains.py
+++ b/api/desecapi/tests/testdomains.py
@@ -1,14 +1,14 @@
-import random
 import json
+import random
 
-from django.core import mail
 from django.conf import settings
+from django.core import mail
 from django.core.exceptions import ValidationError
 from rest_framework import status
 
 from desecapi.exceptions import PdnsException
-from desecapi.tests.base import DesecTestCase, DomainOwnerTestCase, LockedDomainOwnerTestCase
 from desecapi.models import Domain
+from desecapi.tests.base import DesecTestCase, DomainOwnerTestCase, LockedDomainOwnerTestCase
 
 
 class UnauthenticatedDomainTests(DesecTestCase):

--- a/api/desecapi/tests/testdonations.py
+++ b/api/desecapi/tests/testdonations.py
@@ -1,6 +1,6 @@
-from rest_framework.reverse import reverse
-from rest_framework import status
 from django.core import mail
+from rest_framework import status
+from rest_framework.reverse import reverse
 
 from desecapi.tests.base import DesecTestCase
 

--- a/api/desecapi/tests/testprivacychores.py
+++ b/api/desecapi/tests/testprivacychores.py
@@ -3,9 +3,9 @@ from datetime import timedelta
 from django.core.management import call_command
 from django.utils import timezone
 
+from api import settings
 from desecapi.models import User
 from desecapi.tests.base import DesecTestCase
-from api import settings
 
 
 class PrivacyChoresCommandTest(DesecTestCase):

--- a/api/desecapi/tests/testregistration.py
+++ b/api/desecapi/tests/testregistration.py
@@ -1,24 +1,24 @@
 from datetime import timedelta
 
+from django.core import mail
 from django.test import RequestFactory
 from django.utils import timezone
-from django.core import mail
 from rest_framework.reverse import reverse
 from rest_framework.versioning import NamespaceVersioning
 
-from desecapi.tests.base import DesecTestCase
+from api import settings
 from desecapi import models
 from desecapi.emails import send_account_lock_email
-from api import settings
+from desecapi.tests.base import DesecTestCase
 
 
 class RegistrationTestCase(DesecTestCase):
 
-    def assertRegistration(self, REMOTE_ADDR='', status=201, **kwargs):
+    def assertRegistration(self, remote_addr='', status=201, **kwargs):
         url = reverse('v1:register')
         post_kwargs = {}
-        if REMOTE_ADDR:
-            post_kwargs['REMOTE_ADDR'] = REMOTE_ADDR
+        if remote_addr:
+            post_kwargs['REMOTE_ADDR'] = remote_addr
         response = self.client.post(url, kwargs, **post_kwargs)
         self.assertStatus(response, status)
         return response
@@ -32,7 +32,7 @@ class SingleRegistrationTestCase(RegistrationTestCase):
         self.assertRegistration(
             email=email,
             password=self.random_password(),
-            REMOTE_ADDR="1.3.3.7",
+            remote_addr="1.3.3.7",
         )
         self.user = models.User.objects.get(email=email)
 
@@ -59,7 +59,7 @@ class SingleRegistrationTestCase(RegistrationTestCase):
 class MultipleRegistrationTestCase(RegistrationTestCase):
 
     def _registrations(self):
-        pass
+        return []
 
     def setUp(self):
         super().setUp()
@@ -71,7 +71,7 @@ class MultipleRegistrationTestCase(RegistrationTestCase):
                 email=email,
                 password=self.random_password(),
                 dyn=True,
-                REMOTE_ADDR=ip,
+                remote_addr=ip,
             )
             user = models.User.objects.get(email=email)
             self.assertEqual(user.registration_remote_ip, ip)

--- a/api/desecapi/tests/testrrsets.py
+++ b/api/desecapi/tests/testrrsets.py
@@ -230,7 +230,7 @@ class AuthenticatedRRSetTestCase(DomainOwnerTestCase):
             response = self.client.post_rr_set(self.my_empty_domain.name, **data)
             self.assertStatus(response, status.HTTP_201_CREATED)
 
-        data['records'][0] = ['3.2.2.1']
+        data['records'][0] = '3.2.2.1'
         response = self.client.post_rr_set(self.my_empty_domain.name, **data)
         self.assertStatus(response, status.HTTP_409_CONFLICT)
 

--- a/api/desecapi/urls/version_1.py
+++ b/api/desecapi/urls/version_1.py
@@ -4,7 +4,6 @@ from rest_framework.routers import SimpleRouter
 
 from desecapi import views
 
-
 tokens_router = SimpleRouter()
 tokens_router.register(r'', views.TokenViewSet, base_name='token')
 
@@ -38,7 +37,7 @@ api_urls = [
     path('domains/<name>/rrsets/', views.RRsetList.as_view(), name='rrsets'),
     path('domains/<name>/rrsets/.../<type>/', views.RRsetDetail.as_view(), kwargs={'subname': ''}),
     re_path(r'domains/(?P<name>[^/]+)/rrsets/(?P<subname>[^/]*)\.\.\./(?P<type>[^/]+)/',
-                views.RRsetDetail.as_view(), name='rrset'),
+            views.RRsetDetail.as_view(), name='rrset'),
     path('domains/<name>/rrsets/@/<type>/', views.RRsetDetail.as_view(), kwargs={'subname': ''}),
     re_path(r'domains/(?P<name>[^/]+)/rrsets/(?P<subname>[^/]*)@/(?P<type>[^/]+)/',
             views.RRsetDetail.as_view(), name='rrset@'),

--- a/api/desecapi/views.py
+++ b/api/desecapi/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals  # TODO remove!
-
 import base64
 import binascii
 import ipaddress

--- a/api/desecapi/views.py
+++ b/api/desecapi/views.py
@@ -23,6 +23,7 @@ from rest_framework import status
 from rest_framework.authentication import get_authorization_header
 from rest_framework.exceptions import (NotFound, PermissionDenied, ValidationError)
 from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.settings import api_settings
@@ -35,7 +36,7 @@ from api import settings
 from desecapi.emails import send_account_lock_email, send_token_email
 from desecapi.forms import UnlockForm
 from desecapi.models import Domain, User, RRset, Token
-from desecapi.permissions import *
+from desecapi.permissions import IsOwner, IsUnlockedOrDyn, IsUnlocked, IsDomainOwner
 from desecapi.renderers import PlainTextRenderer
 from desecapi.serializers import DomainSerializer, RRsetSerializer, DonationSerializer, TokenSerializer
 
@@ -77,7 +78,7 @@ class TokenViewSet(mixins.CreateModelMixin,
                    mixins.ListModelMixin,
                    GenericViewSet):
     serializer_class = TokenSerializer
-    permission_classes = (permissions.IsAuthenticated, )
+    permission_classes = (IsAuthenticated, )
     lookup_field = 'user_specific_id'
 
     def get_queryset(self):
@@ -96,7 +97,7 @@ class TokenViewSet(mixins.CreateModelMixin,
 
 class DomainList(generics.ListCreateAPIView):
     serializer_class = DomainSerializer
-    permission_classes = (permissions.IsAuthenticated, IsOwner, IsUnlockedOrDyn,)
+    permission_classes = (IsAuthenticated, IsOwner, IsUnlockedOrDyn,)
 
     def get_queryset(self):
         return Domain.objects.filter(owner=self.request.user.pk)
@@ -170,7 +171,7 @@ class DomainList(generics.ListCreateAPIView):
 
 class DomainDetail(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = DomainSerializer
-    permission_classes = (permissions.IsAuthenticated, IsOwner, IsUnlocked,)
+    permission_classes = (IsAuthenticated, IsOwner, IsUnlocked,)
     lookup_field = 'name'
 
     def delete(self, request, *args, **kwargs):
@@ -192,7 +193,7 @@ class DomainDetail(generics.RetrieveUpdateDestroyAPIView):
 
 class RRsetDetail(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = RRsetSerializer
-    permission_classes = (permissions.IsAuthenticated, IsDomainOwner, IsUnlocked,)
+    permission_classes = (IsAuthenticated, IsDomainOwner, IsUnlocked,)
 
     def delete(self, request, *args, **kwargs):
         try:
@@ -250,7 +251,7 @@ class RRsetDetail(generics.RetrieveUpdateDestroyAPIView):
 
 class RRsetList(ListBulkCreateUpdateAPIView):
     serializer_class = RRsetSerializer
-    permission_classes = (permissions.IsAuthenticated, IsDomainOwner, IsUnlocked,)
+    permission_classes = (IsAuthenticated, IsDomainOwner, IsUnlocked,)
 
     def get_queryset(self):
         name = self.kwargs['name']


### PR DESCRIPTION
This commit updates the code style of the API such that the pycharm code inspection is happy on scope

    file[desec]:api//*.py&&!file[desec]:api/venv//*&&!file:api/manage.py&&!file:api/api/wsgi.py&&!file[desec]:api/desecapi/migrations//*

with the exception of 50ish stupid "typos" that are mostly test data, names defined in our dependencies or hashes, cryptographic keys, etc.

In more detail, this PR does the following.

- While fixing all pycharm warnings, I found to test bugs, fixed in e1bb69e and 154545e.
- Most of the easy work is done in a82f3ad. 
- 23dffd3 removes a future import that has no effect in python3
- In 64ac60f, an `import *` is converted in explicit imports
- In 571980c, an override of `perform_create` was made compatible with the parent's signature
- Lastly, 23feb3f makes the dependency of models on the user model `User` explicit on our own implementation. [This **breaks portability** of our Django app into other Django projects.](https://docs.djangoproject.com/en/2.2/topics/auth/customizing/#reusable-apps-and-auth-user-model) However, it enables type guessing in pycharm, and since we are not planning to make our app reusable and and this change is easy to reverse, I thought this is a reasonable choice.

I'd like to integrate the inspection results (or something similar) in our PR checks, but couldn't find a way to do so. Any ideas?