### PR TITLE
fix(ns): switch images from Debian stretch to Ubuntu bionic

### DIFF
--- a/nslord/Dockerfile
+++ b/nslord/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y \
 		dnsutils \
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
 		dirmngr gnupg \
 	--no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN echo 'deb [arch=amd64] http://repo.powerdns.com/debian stretch-auth-41 main' \
+RUN echo 'deb [arch=amd64] http://repo.powerdns.com/ubuntu bionic-auth-41 main' \
       >> /etc/apt/sources.list \
  && echo 'Package: pdns-*' \
       > /etc/apt/preferences.d/pdns \

--- a/nsmaster/Dockerfile
+++ b/nsmaster/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y \
 		dnsutils \
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
 		dirmngr gnupg \
 	--no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN echo 'deb [arch=amd64] http://repo.powerdns.com/debian stretch-auth-41 main' \
+RUN echo 'deb [arch=amd64] http://repo.powerdns.com/ubuntu bionic-auth-41 main' \
       >> /etc/apt/sources.list \
  && echo 'Package: pdns-*' \
       > /etc/apt/preferences.d/pdns \


### PR DESCRIPTION
Debian stretch has an old glibc version which triggers a memory leak.
https://github.com/PowerDNS/pdns/issues/5782#issuecomment-335421980