### PR TITLE
fix(www): also answer get.desec.$DESECSTACK_DOMAIN on port 80

### DIFF
--- a/www/conf/sites-available/99-desec.conf.var
+++ b/www/conf/sites-available/99-desec.conf.var
@@ -5,7 +5,8 @@ server {
 	listen 80;
 	listen [::]:80;
 	server_name www.desec.$DESECSTACK_DOMAIN
-	            desec.$DESECSTACK_DOMAIN;
+	            desec.$DESECSTACK_DOMAIN
+	            get.desec.$DESECSTACK_DOMAIN;
 	
 	include global.conf;
 	


### PR DESCRIPTION
Sorry, forgot that. It's necessary to that Let's Encrypt can do their ACME challenge without a certificate being there yet.