### PR TITLE
Remove Djoser Token Management

### DIFF
--- a/api/desecapi/tests/base.py
+++ b/api/desecapi/tests/base.py
@@ -1,10 +1,10 @@
 import base64
-from contextlib import nullcontext
-from functools import partial, reduce
 import operator
 import random
 import re
 import string
+from contextlib import nullcontext
+from functools import partial, reduce
 from unittest import mock
 
 from django.utils import timezone
@@ -449,7 +449,7 @@ class MockPDNSTestCase(APITestCase):
                       status,
                       response.status_code,
                       response,
-                      str(response.data).replace('\\n', '\n'),
+                      str(response.data).replace('\\n', '\n') if hasattr(response, 'data') else '',
                 ))
 
     @classmethod

--- a/api/desecapi/tests/test_authentication.py
+++ b/api/desecapi/tests/test_authentication.py
@@ -51,7 +51,7 @@ class SignUpLoginTestCase(DesecTestCase):
     LOGIN_ENDPOINT = None
 
     REGISTRATION_STATUS = status.HTTP_201_CREATED
-    LOGIN_STATUS = status.HTTP_200_OK
+    LOGIN_STATUS = status.HTTP_201_CREATED
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -102,23 +102,11 @@ class URLSignUpLoginTestCase(SignUpLoginTestCase):
     REGISTRATION_ENDPOINT = '/api/v1/auth/users/'
     LOGIN_ENDPOINT = '/api/v1/auth/token/login/'
 
-    LOGIN_STATUS = status.HTTP_201_CREATED
-
 
 class LegacyURLSignUpLoginTestCase(SignUpLoginTestCase):
 
     REGISTRATION_ENDPOINT = '/api/v1/auth/users/create/'
     LOGIN_ENDPOINT = '/api/v1/auth/token/create/'
-
-    LOGIN_STATUS = status.HTTP_201_CREATED
-
-
-class LegacyURLSignUpLoginTestCase2(SignUpLoginTestCase):
-
-    REGISTRATION_ENDPOINT = '/api/v1/auth/users/create/'
-    LOGIN_ENDPOINT = '/api/v1/auth/token/create'
-
-    LOGIN_STATUS = status.HTTP_200_OK
 
 
 class TokenAuthenticationTestCase(DynDomainOwnerTestCase):

--- a/api/desecapi/urls/version_1.py
+++ b/api/desecapi/urls/version_1.py
@@ -20,7 +20,6 @@ auth_urls = [
     # Token management
     path('token/login/', views.TokenCreateView.as_view(), name='login'),
     path('token/logout/', views.TokenDestroyView.as_view(), name='logout'),
-    path('', include('djoser.urls.authtoken')),  # note: this is partially overwritten by the two lines above
     path('tokens/', include(tokens_router.urls)),
 
     # User home


### PR DESCRIPTION
We imported the following URL configuration from Djoser
(djoser/urls/authtoken.py):

	urlpatterns = [
	    url(
		r'^token/create/?$',
		views.TokenCreateView.as_view(),
		name='token-create'
	    ),
	    url(
		r'^token/destroy/?$',
		views.TokenDestroyView.as_view(),
		name='token-destroy'
	    ),
	    url(
		r'^token/login/?$',
		views.TokenCreateView.as_view(),
		name='login'
	    ),
	    url(
		r'^token/logout/?$',
		views.TokenDestroyView.as_view(),
		name='logout'
	    ),
	]

Note that the trailing slash is optional in all four routes. While
the api defined four routes overriding the ones defined by Djoser,
they do not cover the case where no trailing slash is given. However,
Djoser's views are not compatible with api's multi-token solution.

This lead to the situation where an attempted login caused a server
error when an user had more than one token and used the Djoser login
view (by not using a trailing slash).

This commit removes Djoser's views from api's routing altogether (it
is not clear why we kept them in the first place). All four views
(names 'token-create', 'token-destroy', 'login', and 'logout') are
covered by api-defined views.

Functionality changes when no trailing slash is given. Previously,
it was mostly working. Now, we always return 301.

Other changes:

- makes test error messages more resilient
- cleans up imports in touched files