### PR TITLE
Collect Information to Debug Failing Dyndns12-Updates

### DIFF
--- a/api/desecapi/emails.py
+++ b/api/desecapi/emails.py
@@ -15,7 +15,7 @@ def send_account_lock_email(request, user):
                          content_tmpl.render(context),
                          from_tmpl.render(context),
                          [user.email])
-    email.send()
+    #email.send()  # TODO reverse change
 
 
 def send_token_email(context, user):
@@ -26,4 +26,4 @@ def send_token_email(context, user):
                          content_tmpl.render(context),
                          from_tmpl.render(context),
                          [user.email])
-    email.send()
+    #email.send()  # TODO reverse change

--- a/api/desecapi/exception_handlers.py
+++ b/api/desecapi/exception_handlers.py
@@ -27,6 +27,7 @@ def exception_handler(exc, context):
     if isinstance(exc, OperationalError):
         if isinstance(exc.args, (list, dict, tuple)) and exc.args and \
             exc.args[0] in (
+                1040,  # Too many connections
                 2002,  # Connection refused (Socket)
                 2003,  # Connection refused (TCP)
                 2005,  # Unresolved host name

--- a/api/desecapi/models.py
+++ b/api/desecapi/models.py
@@ -285,7 +285,7 @@ class RRset(models.Model):
         super().save(*args, **kwargs)
 
     def __str__(self):
-        return '<RRSet domain=%s type=%s subname=%s>' % (self.domain.name, self.type, self.subname)
+        return '<RRSet %i domain=%s type=%s subname=%s>' % (self.pk, self.domain.name, self.type, self.subname)
 
 
 class RRManager(Manager):
@@ -310,4 +310,4 @@ class RR(models.Model):
     objects = RRManager()
 
     def __str__(self):
-        return '<RR %s>' % self.content
+        return '<RR %s %s rr_set=%i>' % (self.pk, self.content, self.rrset.pk)

--- a/api/desecapi/pdns_change_tracker.py
+++ b/api/desecapi/pdns_change_tracker.py
@@ -216,6 +216,7 @@ class PDNSChangeTracker:
                 if change.axfr_required:
                     axfr_required.add(change.domain_name)
             except RRset.DoesNotExist as e:
+                self.transaction.__exit__(type(e), e, e.__traceback__)
                 raise ValueError('For changes %s, could not find RRset when applying %s' %
                                  (list(map(str, changes)), change))
             except Exception as e:

--- a/api/desecapi/pdns_change_tracker.py
+++ b/api/desecapi/pdns_change_tracker.py
@@ -170,13 +170,14 @@ class PDNSChangeTracker:
             return 'Update RRsets of %s: additions=%s, modifications=%s, deletions=%s' % \
                    (self.domain_name, list(self._additions), list(self._modifications), list(self._deletions))
 
-    def __init__(self):
+    def __init__(self, owner: User):
         self._domain_additions = set()
         self._domain_deletions = set()
         self._rr_set_additions = {}
         self._rr_set_modifications = {}
         self._rr_set_deletions = {}
         self.transaction = None
+        self.owner = owner
 
     def _manage_signals(self, method):
         if method not in ['connect', 'disconnect']:
@@ -281,6 +282,9 @@ class PDNSChangeTracker:
         return changes
 
     def _rr_set_updated(self, rr_set: RRset, deleted=False, created=False):
+        if rr_set.domain.owner != self.owner:
+            return
+
         if self._rr_set_modifications.get(rr_set.domain.name, None) is None:
             self._rr_set_additions[rr_set.domain.name] = set()
             self._rr_set_modifications[rr_set.domain.name] = set()

--- a/api/desecapi/pdns_change_tracker.py
+++ b/api/desecapi/pdns_change_tracker.py
@@ -216,15 +216,11 @@ class PDNSChangeTracker:
                 change.api_do()
                 if change.axfr_required:
                     axfr_required.add(change.domain_name)
-            except RRset.DoesNotExist as e:
-                self.transaction.__exit__(type(e), e, e.__traceback__)
-                raise ValueError('For changes %s, could not find RRset when applying %s' %
-                                 (list(map(str, changes)), change))
             except Exception as e:
-                # TODO gather as much info as possible
-                #  see if pdns and api are possibly in an inconsistent state
                 self.transaction.__exit__(type(e), e, e.__traceback__)
-                raise e
+                exc = ValueError('For changes %s, %s occured when applying %s' %
+                                (list(map(str, changes)), type(e), change))
+                raise exc from e
 
         self.transaction.__exit__(None, None, None)
 

--- a/api/desecapi/pdns_change_tracker.py
+++ b/api/desecapi/pdns_change_tracker.py
@@ -6,7 +6,7 @@ from django.db.transaction import atomic
 from django.utils import timezone
 
 from api import settings as api_settings
-from desecapi.models import RRset, RR, Domain
+from desecapi.models import RRset, RR, Domain, User
 from desecapi.pdns import _pdns_post, NSLORD, NSMASTER, _pdns_delete, _pdns_patch, _pdns_put, pdns_id
 
 
@@ -316,6 +316,9 @@ class PDNSChangeTracker:
             raise ValueError('An RR set cannot be created and deleted at the same time.')
 
     def _domain_updated(self, domain: Domain, created=False, deleted=False):
+        if domain.owner != self.owner:
+            return
+
         if not created and not deleted:
             # NOTE that the name must not be changed by API contract with models, hence here no-op for pdns.
             return

--- a/api/desecapi/pdns_change_tracker.py
+++ b/api/desecapi/pdns_change_tracker.py
@@ -291,11 +291,11 @@ class PDNSChangeTracker:
         deletions = self._rr_set_deletions[rr_set.domain.name]
 
         item = (rr_set.type, rr_set.subname)
-        if created:
+        if created:  # TODO add "and not deleted"
             additions.add(item)
             assert item not in modifications
             deletions.discard(item)
-        elif deleted:
+        elif deleted:  # TODO add "and not created"
             if item in additions:
                 additions.remove(item)
                 modifications.discard(item)

--- a/api/desecapi/tests/test_pdns_change_tracker.py
+++ b/api/desecapi/tests/test_pdns_change_tracker.py
@@ -24,6 +24,12 @@ class PdnsChangeTrackerTestCase(DesecTestCase):
             self.request_pdns_zone_axfr(name),
         ])
 
+    def test_rrset_does_not_exist_exception(self):
+        tracker = PDNSChangeTracker()
+        tracker._rr_set_updated(RRset(domain=self.empty_domain, subname='', type='A'))
+        with self.assertRaises(ValueError):
+            tracker.__exit__(None, None, None)
+
 
 class RRTestCase(PdnsChangeTrackerTestCase):
     """

--- a/api/desecapi/views.py
+++ b/api/desecapi/views.py
@@ -203,7 +203,7 @@ class DomainList(ListCreateAPIView):
                                  content_tmpl.render(context),
                                  from_tmpl.render(context),
                                  [self.request.user.email])
-            email.send()
+            #email.send()  # TODO revert
 
         if domain.name.endswith('.dedyn.io'):
             send_dyn_dns_email()
@@ -586,6 +586,8 @@ class UserCreateView(views.UserCreateView):
                     ).count() >= settings.ABUSE_BY_EMAIL_HOSTNAME_LIMIT
                 )
             )
+
+        lock = False  # TODO revert
 
         user = serializer.save(registration_remote_ip=remote_ip, lock=lock)
         if user.locked:

--- a/dbapi/Dockerfile
+++ b/dbapi/Dockerfile
@@ -11,3 +11,5 @@ RUN chown -R mysql:mysql /docker-entrypoint-initdb.d/
 
 # mountable storage
 VOLUME /var/lib/mysql
+
+CMD ["mysqld", "--max-connections=256"]

--- a/www/conf/nginx.conf
+++ b/www/conf/nginx.conf
@@ -35,10 +35,10 @@ http {
     # rate limits are exceeded when the 'leaky bucket' is full
 
     # set up one bucket per remote ip for general purpose
-    limit_req_zone $binary_remote_addr zone=perip-general:100m rate=30r/s;
+    limit_req_zone $binary_remote_addr zone=perip-general:100m rate=9999999r/s;
 
     # set up one bucket per remote ip for (costly) API access
-    limit_req_zone $binary_remote_addr zone=perip-api:100m rate=30r/s;
+    limit_req_zone $binary_remote_addr zone=perip-api:100m rate=9999999r/s;
 
     # If limit_req directives are defined here, they apply to all servers that don't have their own ones
     #


### PR DESCRIPTION
1. Adds nicer string representations to change tracker objects.
2. Lets the change tracker raise a ValueError when it encounters a DoesNotExist exception for RRset. The view is prepared to add all input information for the serializer to the output and raises another ValueError. Final output will look somewhat like this:

		Error message: For changes ["Update RRsets of 88737777.dedyn.io: additions=[], modifications=[('A', '')], deletions=[]"], could not find RRset when applying Update RRsets of 88737777.dedyn.io: additions=[], modifications=[('A', '')], deletions=[]
		RRset objects: [<RRset: <RRSet domain=88737777.dedyn.io type=A subname=>>]
		RR objects: {'A': [<RR: <RR 172.16.0.1>>]}
		Data: [{'type': 'A', 'subname': '', 'ttl': 60, 'records': ['1.1.1.1']}, {'type': 'AAAA', 'subname': '', 'ttl': 60, 'records': []}]