### PR TITLE
Do Not Run API Multi-Threaded

### DIFF
--- a/api/uwsgi.ini
+++ b/api/uwsgi.ini
@@ -3,7 +3,7 @@ socket = [::]:3031
 chdir = /usr/src/app/
 wsgi-file = api/wsgi.py
 processes = 64
-threads = 4
+threads = 1
 #stats = 127.0.0.1:9191
 
 #master = true


### PR DESCRIPTION
**TL;DR: the change tracker is not thread-safe, so don't run it multi-threaded.**

The change tracker relies on Django signals to track model changes that need to be propagated to pdns. Django signals are shared across multi-threading, however not across multi-processing.

The state before this PR is to spawn 64 python processes with four threads each. The state after will be to spawn 64 python processes. This has the additional benefit that we can't exhaust the dbapi connection limit anymore, which is currently at it's [default of 151 connections](https://img-9gag-fun.9cache.com/photo/aVYz0yw_700bwp.webp).

As each worker only receives one request at a time, this fixes the bug caused by multi-threading. When using exclusively multi-processing, signals are separated by request.

(Rationale to prefer this over separation by, say, user: sometimes we want the change tracker to track across user boundaries, e.g. when syncing back from pdns to the API. It's also conceivable to let users administer several domains in parallel, e.g. in an automated setting for ISPs.)

The effectiveness of this PR was verified with the deSEC aquarium, a testing script that can run multiple requests in parallel, that will likely be content of a future PR.

This PR does not fix some other uncaught exceptions that occur when the API is massively queried in parallel, but as far as I can tell, this PR fixes all issues caused by massively parallel requests *of different users*.

(This 2-bit fix will likely my smallest PR for a while.)