### PR TITLE
Fixes Conflict when Adding RRsets in Conflict with CNAMES Marked for Deletion

### DIFF
--- a/api/desecapi/pdns_change_tracker.py
+++ b/api/desecapi/pdns_change_tracker.py
@@ -131,6 +131,15 @@ class PDNSChangeTracker:
                         {
                             'name': RRset.construct_name(subname, self._domain_name),
                             'type': type_,
+                            'ttl': 1,  # some meaningless integer required by pdns's syntax
+                            'changetype': 'REPLACE',  # don't use "DELETE" due to desec-stack#220, PowerDNS/pdns#7501
+                            'records': []
+                        }
+                        for type_, subname in self._deletions
+                    ] + [
+                        {
+                            'name': RRset.construct_name(subname, self._domain_name),
+                            'type': type_,
                             'ttl': RRset.objects.values_list('ttl', flat=True).get(domain__name=self._domain_name,
                                                                                    type=type_, subname=subname),
                             'changetype': 'REPLACE',
@@ -143,14 +152,6 @@ class PDNSChangeTracker:
                             ]
                         }
                         for type_, subname in (self._additions | self._modifications) - self._deletions
-                    ] + [
-                        {
-                            'name': RRset.construct_name(subname, self._domain_name),
-                            'type': type_,
-                            'changetype': 'DELETE',
-                            'records': []
-                        }
-                        for type_, subname in self._deletions
                     ]
             }
 


### PR DESCRIPTION
This fixes #220, where the API was unable to add an RRset that was
in conflict with an existing CNAME RRset, which was required to be
deleted with the same request.

The fix is somewhat magically, as it depends on
- the order in which updates are send to pdns,
- the changetype that is used to delete RRset in pdns (i.e., "DELETE"
  or "REPLACE" with records=[].

For further discussion, see #220.