### PR TITLE
20191108 encrypt confirmation codes

### DIFF
--- a/api/desecapi/crypto.py
+++ b/api/desecapi/crypto.py
@@ -1,0 +1,37 @@
+from base64 import urlsafe_b64encode
+from enum import Enum
+
+from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.kbkdf import CounterLocation, KBKDFHMAC, Mode
+from cryptography.hazmat.backends import default_backend
+from django.conf import settings
+from django.utils.encoding import force_bytes
+
+
+def _derive_urlsafe_key(*, label, context):
+    backend = default_backend()
+    kdf = KBKDFHMAC(algorithm=hashes.SHA256(), mode=Mode.CounterMode, length=32, rlen=4, llen=4,
+                    location=CounterLocation.BeforeFixed, label=label, context=context, fixed=None, backend=backend)
+    key = kdf.derive(settings.SECRET_KEY.encode())
+    return urlsafe_b64encode(key)
+
+
+def retrieve_key(*, label, context):
+    # Keeping this function separate from key derivation gives us freedom to implement look-ups later, e.g. from cache
+    label = force_bytes(label, strings_only=True)
+    context = force_bytes(context, strings_only=True)
+    return _derive_urlsafe_key(label=label, context=context)
+
+
+def encrypt(data, *, context):
+    key = retrieve_key(label=b'crypt', context=context)
+    return Fernet(key=key).encrypt(data)
+
+
+def decrypt(token, *, context, ttl=None):
+    key = retrieve_key(label=b'crypt', context=context)
+    try:
+        return Fernet(key=key).decrypt(token, ttl=ttl)
+    except InvalidToken:
+        raise ValueError

--- a/api/desecapi/tests/test_crypto.py
+++ b/api/desecapi/tests/test_crypto.py
@@ -1,0 +1,56 @@
+from math import log
+
+from django.test import TestCase
+
+from desecapi import crypto
+
+
+class CryptoTestCase(TestCase):
+    context = 'desecapi.tests.test_crypto'
+
+    def test_retrieved_key_is_reproducible(self):
+        keys = (crypto.retrieve_key(label='test', context=self.context) for _ in range(2))
+        self.assertEqual(*keys)
+
+    def test_retrieved_key_depends_on_secret(self):
+        keys = []
+        for secret in ['abcdefgh', 'hgfedcba']:
+            with self.settings(SECRET_KEY=secret):
+                keys.append(crypto.retrieve_key(label='test', context=self.context))
+        self.assertNotEqual(*keys)
+
+    def test_retrieved_key_depends_on_label(self):
+        keys = (crypto.retrieve_key(label=f'test_{i}', context=self.context) for i in range(2))
+        self.assertNotEqual(*keys)
+
+    def test_retrieved_key_depends_on_context(self):
+        keys = (crypto.retrieve_key(label='test', context=f'{self.context}_{i}') for i in range(2))
+        self.assertNotEqual(*keys)
+
+    def test_encrypt_has_high_entropy(self):
+        def entropy(value: str):
+            result = 0
+            counts = [value.count(char) for char in set(value)]
+            for count in counts:
+                count /= len(value)
+                result -= count * log(count, 2)
+            return result * len(value)
+
+        ciphertext = crypto.encrypt(b'test', context=self.context)
+        self.assertGreater(entropy(ciphertext), 100)  # arbitrary
+
+    def test_encrypt_decrypt(self):
+        plain = b'test'
+        ciphertext = crypto.encrypt(plain, context=self.context)
+        self.assertEqual(plain, crypto.decrypt(ciphertext, context=self.context))
+
+    def test_encrypt_decrypt_raises_on_tampering(self):
+        ciphertext = crypto.encrypt(b'test', context=self.context)
+
+        with self.assertRaises(ValueError):
+            ciphertext_decoded = ciphertext.decode()
+            ciphertext_tampered = (ciphertext_decoded[:30] + 'TAMPERBEEF' + ciphertext_decoded[40:]).encode()
+            crypto.decrypt(ciphertext_tampered, context=self.context)
+
+        with self.assertRaises(ValueError):
+            crypto.decrypt(ciphertext, context=f'{self.context}2')

--- a/api/desecapi/views.py
+++ b/api/desecapi/views.py
@@ -541,7 +541,10 @@ class AuthenticatedActionView(generics.GenericAPIView):
             data = {**request.data, 'code': self.view.kwargs['code']}  # order crucial to avoid override from payload!
             serializer = self.view.serializer_class(data=data, context=self.view.get_serializer_context())
             serializer.is_valid(raise_exception=True)
-            self.view.authenticated_action = serializer.instance
+            try:
+                self.view.authenticated_action = serializer.Meta.model(**serializer.validated_data)
+            except ValueError:
+                raise ValidationError()
 
             return self.view.authenticated_action.user, None
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,5 +1,7 @@
+captcha~=0.3.0
 celery~=4.3.0
 coverage~=4.5.3
+cryptography~=2.8
 Django~=2.2.0
 django-cors-headers~=3.1.1
 djangorestframework~=3.10.3
@@ -9,4 +11,3 @@ mysqlclient~=1.4.0
 psl-dns~=1.0rc2
 requests~=2.21.0
 uwsgi~=2.0.0
-captcha~=0.3.0


### PR DESCRIPTION
Pretty straightforward. Three questions:

- Should we put `SECRET_KEY_SIGN` and `SECRET_KEY_ENCRYPT` in a central place? They are currently in the files where they're needed.
- Should the key derivation be done differently? There's [serious stuff](https://cryptography.io/en/latest/hazmat/primitives/key-derivation-functions/) out there, but it looks complicated. Let's figure out what's an acceptable approach.
- What's the right way to test this (e.g. that different keys are really being used)?