### PR TITLE
feat(api): add fast / slow lane depending on email type, closes #242

### DIFF
--- a/api/api/celery.py
+++ b/api/api/celery.py
@@ -4,7 +4,7 @@ from celery import Celery
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'api.settings')
 
-app = Celery('api')
+app = Celery('api', include='desecapi.mail_backends')
 app.config_from_object('django.conf:settings', namespace='CELERY')
 app.autodiscover_tasks()
 

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -42,7 +42,6 @@ INSTALLED_APPS = (
     'rest_framework',
     'desecapi.apps.AppConfig',
     'corsheaders',
-    'djcelery_email',
 )
 
 MIDDLEWARE = (
@@ -119,7 +118,7 @@ TEMPLATES = [
 ]
 
 # How and where to send mail
-EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
+EMAIL_BACKEND = 'desecapi.mail_backends.MultiLaneEmailBackend'
 EMAIL_HOST = os.environ['DESECSTACK_API_EMAIL_HOST']
 EMAIL_HOST_USER = os.environ['DESECSTACK_API_EMAIL_HOST_USER']
 EMAIL_HOST_PASSWORD = os.environ['DESECSTACK_API_EMAIL_HOST_PASSWORD']
@@ -144,13 +143,12 @@ NSMASTER_PDNS_API_TOKEN = os.environ['DESECSTACK_NSMASTER_APIKEY']
 
 # Celery
 CELERY_BROKER_URL = 'amqp://rabbitmq'
-CELERY_EMAIL_CHUNK_SIZE = 1
-CELERY_EMAIL_TASK_CONFIG = {
-    'queue' : 'celery',
-    'rate_limit' : '3/m',
-}
-CELERY_TASK_DEFAULT_RATE_LIMIT = '3/m'
+CELERY_EMAIL_MESSAGE_EXTRA_ATTRIBUTES = []  # required because djcelery_email.utils accesses it
 CELERY_TASK_TIME_LIMIT = 30
+TASK_CONFIG = {
+    'email_fast_lane': {'rate_limit': '1/s'},
+    'email_slow_lane': {'rate_limit': '3/m'},
+}
 
 # pdns accepts request payloads of this size.
 # This will hopefully soon be configurable: https://github.com/PowerDNS/pdns/pull/7550

--- a/api/api/settings_quick_test.py
+++ b/api/api/settings_quick_test.py
@@ -19,3 +19,6 @@ PASSWORD_HASHERS = [
 ]
 
 REST_FRAMEWORK['PAGE_SIZE'] = 20
+
+# Carry email backend connection over to test mail outbox
+CELERY_EMAIL_MESSAGE_EXTRA_ATTRIBUTES = ['connection']

--- a/api/desecapi/mail_backends.py
+++ b/api/desecapi/mail_backends.py
@@ -1,0 +1,47 @@
+import logging
+
+from celery import shared_task
+from django.conf import settings
+from django.core.mail import get_connection
+from django.core.mail.backends.base import BaseEmailBackend
+from djcelery_email.utils import dict_to_email, email_to_dict
+
+
+logger = logging.getLogger(__name__)
+
+
+class MultiLaneEmailBackend(BaseEmailBackend):
+    config = {'ignore_result': True, 'queue': 'celery'}
+    default_backend = 'django.core.mail.backends.smtp.EmailBackend'
+
+    def __init__(self, lane: str, fail_silently=False, **kwargs):
+        self.config.update(name=lane)
+        self.config.update(settings.TASK_CONFIG[lane])
+        self.task_kwargs = kwargs.copy()
+        # Make a copy tor ensure we don't modify input dict when we set the 'lane'
+        self.task_kwargs['debug'] = self.task_kwargs.pop('debug', {}).copy()
+        self.task_kwargs['debug']['lane'] = lane
+        super().__init__(fail_silently)
+
+    def send_messages(self, email_messages):
+        dict_messages = [email_to_dict(msg) for msg in email_messages]
+        TASKS[self.config['name']].delay(dict_messages, **self.task_kwargs)
+        return len(email_messages)
+
+    @staticmethod
+    def _run_task(messages, debug, **kwargs):
+        logger.warning('Sending queued email, details: %s', debug)
+        kwargs.setdefault('backend', kwargs.pop('backbackend', MultiLaneEmailBackend.default_backend))
+        with get_connection(**kwargs) as connection:
+            return connection.send_messages([dict_to_email(message) for message in messages])
+
+    @property
+    def task(self):
+        return shared_task(**self.config)(self._run_task)
+
+
+# Define tasks so that Celery can discovery them
+TASKS = {
+    name: MultiLaneEmailBackend(lane=name, fail_silently=True).task
+    for name in settings.TASK_CONFIG
+}

--- a/api/desecapi/tests/test_mail_backends.py
+++ b/api/desecapi/tests/test_mail_backends.py
@@ -1,0 +1,30 @@
+from unittest import mock
+
+from django.conf import settings
+from django.core import mail
+from django.core.mail import EmailMessage, get_connection
+from django.test import TestCase
+
+from desecapi import mail_backends
+
+
+@mock.patch.dict(mail_backends.TASKS,
+                 {key: type('obj', (object,), {'delay': mail_backends.MultiLaneEmailBackend._run_task})
+                  for key in mail_backends.TASKS})
+class MultiLaneEmailBackendTestCase(TestCase):
+    test_backend = settings.EMAIL_BACKEND
+
+    def test_lanes(self):
+        debug_params = {'foo': 'bar'}
+        debug_params_orig = debug_params.copy()
+
+        with self.settings(EMAIL_BACKEND='desecapi.mail_backends.MultiLaneEmailBackend'):
+            for lane in ['email_slow_lane', 'email_fast_lane']:
+                subject = f'Test subject for lane {lane}'
+                connection = get_connection(lane=lane, backbackend=self.test_backend, debug=debug_params)
+                EmailMessage(subject=subject, to=['to@test.invalid'], connection=connection).send()
+                self.assertDictEqual(mail.outbox[-1].connection.task_kwargs['debug'], {'lane': lane, **debug_params})
+                self.assertEqual(mail.outbox[-1].subject, subject)
+
+        # Check that the backend hasn't modified the dict we passed
+        self.assertEqual(debug_params, debug_params_orig)


### PR DESCRIPTION
Todos:

- add some more logging at sending time to see which track is being sent from (Celery)
- think about making it nicer, somehow (`mail_backends.py` has two dicts, a class, a function, and a loop ...)
- add some tests. @nils-wisiol , what exactly do you think we should test?