### PR TITLE
fix(api,nsmaster): fix max body size to accommodate catalog zone

### DIFF
--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -182,7 +182,7 @@ TASK_CONFIG = {  # The first entry is the default queue
 
 # pdns accepts request payloads of this size.
 # This will hopefully soon be configurable: https://github.com/PowerDNS/pdns/pull/7550
-PDNS_MAX_BODY_SIZE = 2 * 1024 * 1024
+PDNS_MAX_BODY_SIZE = 16 * 1024 * 1024
 
 # SEPA direct debit settings
 SEPA = {

--- a/nsmaster/conf/pdns.conf.var
+++ b/nsmaster/conf/pdns.conf.var
@@ -11,6 +11,7 @@ version-string=powerdns
 webserver=yes
 webserver-address=${DESECSTACK_IPV4_REAR_PREFIX16}.1.12
 webserver-allow-from=${DESECSTACK_IPV4_REAR_PREFIX16}.1.10
+webserver-max-bodysize=16
 carbon-server=${DESECSTACK_NSMASTER_CARBONSERVER}
 carbon-ourname=${DESECSTACK_NSMASTER_CARBONOURNAME}
 


### PR DESCRIPTION
The catalog zone request currently has 2.9 MB. The previous limit
for request bodies in nsmaster was 2 MB. This comit sets it to
16 MB which should suffice for the forseeable future.

Future work on the replication mechanism can entirely elimitate
the need to provision the zone atomically, so that smaller chunks
can be committed.