### PR TITLE
fix(openvpn-server): invalid TCP configuration

### DIFF
--- a/openvpn-server/conf/server.conf
+++ b/openvpn-server/conf/server.conf
@@ -164,8 +164,8 @@ verb 3
 ;mute 20
 
 # Notify the client that when the server restarts so it
-# can automatically reconnect.
-explicit-exit-notify 1
+# can automatically reconnect. UDP only!
+;explicit-exit-notify 1
 
 script-security 2
 route-up "/usr/sbin/service pimd start"


### PR DESCRIPTION
I verified that OpenVPN starts up correctly with this fix.