### PR TITLE
feat(www): compress /api/v1/serials/ endpoint

### DIFF
--- a/www/conf/sites-available/90-desec.api.location.var
+++ b/www/conf/sites-available/90-desec.api.location.var
@@ -9,4 +9,10 @@ location /api/ {
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload" always;
     include uwsgi_params;
     uwsgi_pass desecapi;
+
+    location /api/v1/serials/ {
+        gzip on;
+        gzip_types *;
+        uwsgi_pass desecapi;
+    }
 }


### PR DESCRIPTION
Tests have shown that size after compression is around 23%.
Python "requests" automatically asks for gzip, so no need for
change on the slave.

This branch is sandbox-tested.