### PR TITLE
20200328 improve signup

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -47,7 +47,7 @@
           <v-icon :color="item.post_icon_color" class="ml-1 text--darken-1" small v-if="item.post_icon">{{item.post_icon}}</v-icon>
         </span>
       </div>
-      <v-btn class="mx-4 mr-0" color="primary" depressed :to="{name: 'signup'}">Create Account</v-btn>
+      <v-btn class="mx-4 mr-0" color="primary" depressed :to="{name: 'signup', query: $route.query}">Create Account</v-btn>
       <v-app-bar-nav-icon class="d-md-none" @click.stop="drawer = !drawer" />
     </v-app-bar>
 

--- a/webapp/src/router/index.js
+++ b/webapp/src/router/index.js
@@ -73,7 +73,11 @@ const routes = [
 const router = new VueRouter({
   mode: 'history',
   base: process.env.BASE_URL,
-  scrollBehavior () {
+  scrollBehavior (to, from) {
+    // Skip if destination full path has query parameters and differs in no other way from previous
+    if (from && Object.keys(to.query).length) {
+      if (to.fullPath.split('?')[0] == from.fullPath.split('?')[0]) return;
+    }
     return { x: 0, y: 0 }
   },
   routes

--- a/webapp/src/validation.js
+++ b/webapp/src/validation.js
@@ -1,2 +1,2 @@
-export const domain_pattern = /^[a-z0-9_.-]*[a-z]$/i;
+export const domain_pattern = /^([a-z0-9_.-]+\.)+[a-z]+$/i;
 export const email_pattern = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;

--- a/webapp/src/views/Home.vue
+++ b/webapp/src/views/Home.vue
@@ -6,7 +6,7 @@
       <v-row align="center">
         <v-col class="col-md-6 col-12 py-8 triangle-fg">
           <h1 class="display-1 font-weight-bold">Modern DNS Hosting for Everyone</h1>
-          <h3 class="subheading mt-2 py-8 font-weight-regular">
+          <h3 class="subheading mt-2 pt-8 font-weight-regular">
             <p>
               deSEC is a <strong>free DNS hosting</strong> service, <strong>designed with security in mind</strong>.
             </p>
@@ -19,6 +19,16 @@
             <v-form @submit.prevent="signup" :value="valid" ref="form">
               <v-row>
                 <v-col md="9" cols="12">
+                  <v-radio-group
+                          v-model="domainType"
+                          class="justify-center pb-2"
+                          hide-details
+                          row
+                          @change="$router.push({query: {domainType: domainType}})"
+                  >
+                    <v-radio class="pb-2" label="dynDNS account" value="dynDNS" selected></v-radio>
+                    <v-radio class="pb-2" label="Managed DNS account" value="custom"></v-radio>
+                  </v-radio-group>
                   <v-text-field
                     outlined
                     solo
@@ -156,13 +166,19 @@ export default {
   },
   methods: {
     async signup() {
-      if (this.$refs.form.validate()) this.$router.push({name: 'signup', params: this.email !== '' ? {email: this.email} : {}});
+      if (this.$refs.form.validate()) {
+        this.$router.push({name: 'signup', params: this.email ? {email: this.email} : {}, query: {domainType: this.domainType}});
+      }
     },
   },
-  data: () => ({
+  created() {
+    this.domainType = this.$route.query.domainType || 'none';
+  },
+    data: () => ({
     contact_email: EMAIL,
     contact_subject: 'Adopting of a Frontend Server',
     contact_body: 'Dear deSEC,\n\nI would like to adopt a frontend server in your networks!',
+    domainType: null,
     email: '',
     email_rules: [
       v => !!email_pattern.test(v || '') || 'Invalid email address.'

--- a/webapp/src/views/ResetPassword.vue
+++ b/webapp/src/views/ResetPassword.vue
@@ -60,8 +60,10 @@
                                     tabindex="1"
                             />
 
-                            <v-layout>
-                                <v-text-field
+                              <v-container class="pa-0">
+                                <v-row dense align="center" class="text-center">
+                                  <v-col cols="12" sm="">
+                                    <v-text-field
                                             v-model="captchaSolution"
                                             label="Type CAPTCHA text here"
                                             prepend-icon="mdi-account-check"
@@ -74,9 +76,10 @@
                                             @keypress="captcha_errors=[]"
                                             class="uppercase"
                                             ref="captchaField"
-                                            tabindex="2"
-                                />
-                                <div class="ml-4 text-center">
+                                            tabindex="3"
+                                    />
+                                  </v-col>
+                                  <v-col cols="8" sm="auto">
                                     <v-progress-circular
                                             indeterminate
                                             v-if="captchaWorking"
@@ -86,11 +89,12 @@
                                             :src="'data:image/png;base64,'+captcha.challenge"
                                             alt="Passwords can also be reset by sending an email to our support."
                                     >
-                                    <br/>
-                                    <v-btn text outlined @click="getCaptcha(true)" :disabled="captchaWorking">New Captcha
-                                    </v-btn>
-                                </div>
-                            </v-layout>
+                                  </v-col>
+                                  <v-col cols="4" sm="auto">
+                                    <v-btn text outlined @click="getCaptcha(true)" :disabled="captchaWorking"><v-icon>mdi-refresh</v-icon></v-btn>
+                                  </v-col>
+                                </v-row>
+                              </v-container>
                         </v-card-text>
                         <v-card-actions class="justify-center">
                             <v-btn

--- a/webapp/src/views/SignUp.vue
+++ b/webapp/src/views/SignUp.vue
@@ -72,8 +72,10 @@
                       tabindex="2"
               />
 
-              <v-layout>
-                <v-text-field
+              <v-container class="pa-0">
+                <v-row dense align="center" class="text-center">
+                  <v-col cols="12" sm="">
+                    <v-text-field
                         v-model="captchaSolution"
                         label="Type CAPTCHA text here"
                         prepend-icon="mdi-account-check"
@@ -87,21 +89,24 @@
                         class="uppercase"
                         ref="captchaField"
                         tabindex="3"
-                />
-                <div class="ml-4 text-center">
-                  <v-progress-circular
+                    />
+                  </v-col>
+                  <v-col cols="8" sm="auto">
+                    <v-progress-circular
                           indeterminate
                           v-if="captchaWorking"
-                  ></v-progress-circular>
-                  <img
+                    ></v-progress-circular>
+                    <img
                           v-if="captcha && !captchaWorking"
                           :src="'data:image/png;base64,'+captcha.challenge"
                           alt="Sign up is also possible by sending an email to our support."
-                  >
-                  <br/>
-                  <v-btn text outlined @click="getCaptcha(true)" :disabled="captchaWorking">New Captcha</v-btn>
-                </div>
-              </v-layout>
+                    >
+                  </v-col>
+                  <v-col cols="4" sm="auto">
+                    <v-btn text outlined @click="getCaptcha(true)" :disabled="captchaWorking"><v-icon>mdi-refresh</v-icon></v-btn>
+                  </v-col>
+                </v-row>
+              </v-container>
 
               <v-layout class="justify-center">
                 <v-checkbox

--- a/webapp/src/views/Terms.vue
+++ b/webapp/src/views/Terms.vue
@@ -74,8 +74,8 @@ export default {
         title: 'Users Must be Responsive',
         text: 'Users are required to register with an email address and are obliged to read and react to our ' +
                 'emails. For users who do not react or are uncooperative, deSEC reserves the right to disable the ' +
-                'account zone, and/or modify or disable DNS records or zones in order to ensure smooth operation of ' +
-                'deSEC services.',
+                'account and/or zone, and/or modify or disable DNS records or zones in order to ensure smooth ' +
+                'operation of deSEC services.',
       },
       {
         title: 'Expiration of Inactive dynDNS Domains',


### PR DESCRIPTION
From your [earlier feedback](https://github.com/desec-io/desec-stack/pull/314#issuecomment-605428852):

> bug: redirect URL to the welcome page contains the wrong domain name for "managed DNS"

Fixed

> optics: let's checkout if tabs could look better than radio buttons

I do not think this is a good solution for two reasons:
a) We can't have tabs on the main page where you can already preselect the account type, before opening the modal. I think though that the UI element to specify the account type should be consistent whenever it appears, i.e. if we have a radio button on the main page, it should also be a radio button in the modal.
b) Different tabs usually are for things that are not mutually exclusive, but instead are not of interest at all times (such as a typical options dialog). Tabs therefore usually have independent content. In our case, the tab contents would be nearly identical. Overall, I'd say they are not associated with "making a choice", but with "dealing with another aspect".

If you still would like to see the comparison, I can of course implement it.

-- 

I also fixed a bug, which had caused scrolling to the top when changing the account type selection on the main page. The new behavior is that when navigation occurs which leads to a destination that only differs in the query string, scrolling is not done. (When the query string is removed, that's an exception -- like when clicking on the deSEC logo, you want to see things scroll to the top.)