### PR TITLE
fix(nsmaster): set IP TTL for outgoing packets to fix occasional TTL=1

### DIFF
--- a/nsmaster/Dockerfile
+++ b/nsmaster/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -y \
 		dnsutils \
+		iptables \
 		net-tools \
 		dirmngr gnupg \
 	--no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/nsmaster/entrypoint.sh
+++ b/nsmaster/entrypoint.sh
@@ -4,6 +4,10 @@
 /sbin/ip route add 10.8.0.0/24 via 172.16.7.2
 /sbin/ip route add 239.1.2.0/24 via 172.16.7.2
 
+# Fix UDP TTL which sometimes is one, causing packets intended for VPN clients to be dropped at the VPN server
+# TODO remove this workaround once the problem has been solved at its root
+iptables -t mangle -A OUTPUT -p udp -j TTL --ttl-set 64
+
 host=dbmaster; port=3306; n=120; i=0; while ! (echo > /dev/tcp/$host/$port) 2> /dev/null; do [[ $i -eq $n ]] && >&2 echo "$host:$port not up after $n seconds, exiting" && exit 1; echo "waiting for $host:$port to come up"; sleep 1; i=$((i+1)); done
 
 # Manage credentials


### PR DESCRIPTION
UDP packets originating from nsmaster usually have IP TTL=64 set, but sporadically (~10% of cases) the TTL is 1, and the packet does not live beyond the first hop, which happens to be the VPN server.

I identified two successive queries coming from the same slave, asking for SOA records for two different domains; the packet structure is the same. The nameserver Docker container decided to answer one with TTL=64 in the packet, and the other with TTL=1:

```
23:38:57.064189 IP (tos 0x0, ttl 62, id 16983, offset 0, flags [DF], proto UDP (17), length 78)
    10.8.0.21.11569 > 172.16.7.3.53: 1277 [1au] SOA? <masked-1>.dedyn.io. (50)
23:38:57.064358 IP (tos 0x0, ttl 62, id 16984, offset 0, flags [DF], proto UDP (17), length 73)
    10.8.0.21.11569 > 172.16.7.3.53: 7951 [1au] SOA? <masked-2>.dedyn.io. (45)
23:38:57.064883 IP (tos 0x0, ttl 64, id 16979, offset 0, flags [none], proto UDP (17), length 255)
    172.16.7.3.53 > 10.8.0.21.11569: 1277*- 2/0/1 <masked-1>.dedyn.io. SOA set.an.example. get.desec.io. 2019074124 10800 3600 604800 60, <masked-1>.dedyn.io. RRSIG (227)
23:38:57.064951 IP (tos 0x0, ttl 1, id 16980, offset 0, flags [none], proto UDP (17), length 245)
    172.16.7.3.53 > 10.8.0.21.11569: 7951*- 2/0/1 <masked-2>.dedyn.io. SOA set.an.example. get.desec.io. 2019075224 10800 3600 604800 60, <masked-2>.dedyn.io. RRSIG (217)
```

The problem goes away with `iptables -t mangle -A OUTPUT -p udp -j TTL --ttl-set 64` which is what this PR tentatively proposes. But that is obviously an ugly workaround.
