### PR TITLE
fix(nsmaster): increase max number of DNS TCP connections

### DIFF
--- a/nsmaster/conf/pdns.conf.var
+++ b/nsmaster/conf/pdns.conf.var
@@ -7,6 +7,7 @@ setgid=pdns
 setuid=pdns
 slave=yes
 slave-renotify=yes
+max-tcp-connections=200
 version-string=powerdns
 webserver=yes
 webserver-address=${DESECSTACK_IPV4_REAR_PREFIX16}.1.12


### PR DESCRIPTION
Logs have:
> Limit of simultaneous TCP connections reached - raise max-tcp-connections

Probably due to simultaneous AXFRs.