### PR TITLE
Update Randomness Sources

### DIFF
--- a/api/desecapi/models.py
+++ b/api/desecapi/models.py
@@ -9,7 +9,6 @@ import uuid
 from base64 import urlsafe_b64encode
 from datetime import timedelta
 from hashlib import sha256
-from os import urandom
 
 import psl_dns
 import rest_framework.authtoken.models
@@ -183,7 +182,7 @@ class Token(ExportModelOperationsMixin('Token'), rest_framework.authtoken.models
     plain = None
 
     def generate_key(self):
-        self.plain = urlsafe_b64encode(urandom(21)).decode()
+        self.plain = secrets.token_urlsafe(21)
         self.key = Token.make_hash(self.plain)
         return self.key
 

--- a/api/desecapi/pdns_change_tracker.py
+++ b/api/desecapi/pdns_change_tracker.py
@@ -1,4 +1,4 @@
-import random
+import secrets
 import socket
 
 from django.conf import settings
@@ -85,7 +85,7 @@ class PDNSChangeTracker:
             return True
 
         def pdns_do(self):
-            salt = '%016x' % random.randrange(16 ** 16)
+            salt = secrets.token_hex(nbytes=8)
             _pdns_post(
                 NSLORD, '/zones?rrsets=false',
                 {


### PR DESCRIPTION
This changes the source of randomness for

1. NSEC3 param salt (for new domains), from `random` to `secrets`,
2. authentication tokens, from `urandom` to `secrets`.

Rationale:

1. Creating domains is expensive anyhow, we can afford a little more time spend on the salt generation. 
2. We abstract from the OS and use Python's interface for generating secrets instead of having to worry about the OS interface (like `/dev/random` vs `/dev/urandom`).