### PR TITLE
wip(api): OpenAPI schema, closes #359

### DIFF
--- a/api/api/urls.py
+++ b/api/api/urls.py
@@ -55,7 +55,7 @@ from django.urls import include, path
 # if no other information is available, the last-specified version will be used as default for reversing URLs
 urlpatterns = [
     # other available versions in no particular order
-    path('api/v2/', include('desecapi.urls.version_2', namespace='v2')),
+    #path('api/v2/', include('desecapi.urls.version_2', namespace='v2')),
     # the DEFAULT version
     path('api/v1/', include('desecapi.urls.version_1', namespace='v1')),
     # monitoring

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -16,4 +16,5 @@ psl-dns~=1.0
 pylibmc~=1.6.1
 pyyaml~=5.4.1
 requests~=2.25.0
+uritemplate~=3.0.1
 uwsgi~=2.0.0


### PR DESCRIPTION
Todos:

- [ ] The [`NonBulkOnlyDefault` that we use for `RRsetSerializer.subname`](https://github.com/desec-io/desec-stack/blob/f141a37/api/desecapi/serializers.py#L212) is not serializable. As a consequence, JSON schema generation crashes, and YML schema generation produces a broken file. (The schema file included in this PR was generated with this default removed.) @nils-wisiol, do you have any idea what to do about this?
- [ ] Some adaptions in the views were necessary because the views usually assume presence of `self.request` or `self.domain`, which is not guaranteed in the way the schema generator instantiates the views. Let's take a look whether the fixes can be done in a better way.
- [ ] Remove `/api/v2/`?
- [ ] Come up with a way of publishing the schema automatically. How? (Via Django? Or generate a static file and check it into `webapp/`? Something else?)

`AuthenticatedActionView.action` was renamed to `AuthenticatedActionView.auth_action` because `.action` is used by DRF `ViewSet`, and it seems that the schema generator mistakenly assumes certain things about `.action` as if `AuthenticatedActionView` was a `ViewSet` (but it's not). The problem went away by using another name.