### PR TITLE
BREAKING feat(nslord,nsmaster): upgrade to pdns 4.3

### DIFF
--- a/dblord/initdb.d/10-pdns-lord.sql
+++ b/dblord/initdb.d/10-pdns-lord.sql
@@ -6,7 +6,7 @@ CREATE TABLE domains (
   master                VARCHAR(128) DEFAULT NULL,
   last_check            INT DEFAULT NULL,
   type                  VARCHAR(6) NOT NULL,
-  notified_serial       INT DEFAULT NULL,
+  notified_serial       INT UNSIGNED DEFAULT NULL,
   account               VARCHAR(40) CHARACTER SET 'utf8' DEFAULT NULL,
   PRIMARY KEY (id)
 ) Engine=InnoDB CHARACTER SET 'latin1';
@@ -22,7 +22,6 @@ CREATE TABLE records (
   content               VARCHAR(64000) DEFAULT NULL,
   ttl                   INT DEFAULT NULL,
   prio                  INT DEFAULT NULL,
-  change_date           INT DEFAULT NULL,
   disabled              TINYINT(1) DEFAULT 0,
   ordername             VARCHAR(255) BINARY DEFAULT NULL,
   auth                  TINYINT(1) DEFAULT 1,
@@ -73,6 +72,7 @@ CREATE TABLE cryptokeys (
   domain_id             INT NOT NULL,
   flags                 INT NOT NULL,
   active                BOOL,
+  published             BOOL DEFAULT 1,
   content               TEXT,
   PRIMARY KEY(id)
 ) Engine=InnoDB CHARACTER SET 'latin1';

--- a/dbmaster/initdb.d/10-pdns-master.sql
+++ b/dbmaster/initdb.d/10-pdns-master.sql
@@ -6,7 +6,7 @@ CREATE TABLE domains (
   master                VARCHAR(128) DEFAULT NULL,
   last_check            INT DEFAULT NULL,
   type                  VARCHAR(6) NOT NULL,
-  notified_serial       INT DEFAULT NULL,
+  notified_serial       INT UNSIGNED DEFAULT NULL,
   account               VARCHAR(40) CHARACTER SET 'utf8' DEFAULT NULL,
   PRIMARY KEY (id)
 ) Engine=InnoDB CHARACTER SET 'latin1';
@@ -22,7 +22,6 @@ CREATE TABLE records (
   content               VARCHAR(64000) DEFAULT NULL,
   ttl                   INT DEFAULT NULL,
   prio                  INT DEFAULT NULL,
-  change_date           INT DEFAULT NULL,
   disabled              TINYINT(1) DEFAULT 0,
   ordername             VARCHAR(255) BINARY DEFAULT NULL,
   auth                  TINYINT(1) DEFAULT 1,
@@ -73,6 +72,7 @@ CREATE TABLE cryptokeys (
   domain_id             INT NOT NULL,
   flags                 INT NOT NULL,
   active                BOOL,
+  published             BOOL DEFAULT 1,
   content               TEXT,
   PRIMARY KEY(id)
 ) Engine=InnoDB CHARACTER SET 'latin1';

--- a/nslord/Dockerfile
+++ b/nslord/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
 		dirmngr gnupg \
 	--no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN echo 'deb [arch=amd64] http://repo.powerdns.com/ubuntu bionic-auth-42 main' \
+RUN echo 'deb [arch=amd64] http://repo.powerdns.com/ubuntu bionic-auth-43 main' \
       >> /etc/apt/sources.list \
  && echo 'Package: pdns-*' \
       > /etc/apt/preferences.d/pdns \

--- a/nsmaster/Dockerfile
+++ b/nsmaster/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
 		dirmngr gnupg \
 	--no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN echo 'deb [arch=amd64] http://repo.powerdns.com/ubuntu bionic-auth-42 main' \
+RUN echo 'deb [arch=amd64] http://repo.powerdns.com/ubuntu bionic-auth-43 main' \
       >> /etc/apt/sources.list \
  && echo 'Package: pdns-*' \
       > /etc/apt/preferences.d/pdns \


### PR DESCRIPTION
This comes with a mandatory database migration on dblord and dbmaster,
https://github.com/PowerDNS/pdns/blob/rel/auth-4.3.x/modules/gmysqlbackend/4.2.0_to_4.3.0_schema.mysql.sql

The commit also contains two small fixes in the database schema that
are not mandatory to apply.