### PR TITLE
feat(webapp): adds link to GitHub projects page ("roadmap")

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -171,6 +171,11 @@ export default {
         'icon': 'mdi-book-open-page-variant',
         'text': 'API Reference',
       },
+      'roadmap': {
+        'name': 'roadmap',
+        'icon': 'mdi-road-variant',
+        'text': 'Roadmap',
+      },
       'talk': {
         'name': 'talk',
         'icon': 'mdi-forum-outline',

--- a/webapp/src/router/index.js
+++ b/webapp/src/router/index.js
@@ -75,6 +75,11 @@ const routes = [
     component: () => import('../views/Donate.vue')
   },
   {
+    path: '//github.com/desec-io/desec-stack/projects?query=is%3Aopen+sort%3Aname-asc',
+    name: 'roadmap',
+    beforeEnter(to) { location.href = to.path },
+  },
+  {
     path: '/impressum/',
     name: 'impressum',
     component: () => import('../views/Impressum.vue')


### PR DESCRIPTION
This just adds a link to a pre-sorted list of projects in our GitHub repository. Downsides:

- we can't add a banner text on top or bottom to explain things
- it leaves our website, doesn't appear in our style

On the other hand, I played around with the GitHub API to retrieve the same info and display it on our website instead. Problems:

- it requires authentication (not sure why, actually)
- this part of the github API is experimental

I created a oneliner to extract the info from GitHub and then copy-paste it into the projects, but this outdates quickly, and progress info may be hard to add (it's not pre-computed by the API and would be needed to be scraped manually). It's along the lines of:

      # go to https://github.com/settings/tokens and generate a new access token
      # that is able to access public repos. Then,
      GITHUB_USER=...
      GITHUB_TOKEN=...
      http -a $GITHUB_USER:$GITHUB_TOKEN https://api.github.com/repos/desec-io/desec-stack/projects \
           Accept:"application/vnd.github.inertia-preview+json" | \
           jq '[.[] | {name: .name, body: .body, url: .html_url}]'

And would output something like

```json
[
  {
    "name": "Record Content Validation",
    "body": "Moves validation of record contents from nslord to the API, which has advantages in performance, security, and usability.",
    "url": "https://github.com/desec-io/desec-stack/projects/2",
    "updated": "2020-05-16T06:44:27Z"
  },
  {
    "name": "Webapp Basics",
    "body": "Introduce a basic web-based management application using the deSEC API, providing a login area to manage domains, manage authentication tokens, change the account email address, and delete the account.",
    "url": "https://github.com/desec-io/desec-stack/projects/3",
    "updated": "2020-05-15T22:42:11Z"
  },
  {
    "name": "Two-Factor Authentication",
    "body": "Adds two-factor authentication to increase account security.",
    "url": "https://github.com/desec-io/desec-stack/projects/6",
    "updated": "2020-05-16T06:49:27Z"
  },
  {
    "name": "Lower Contribution Barrier",
    "body": "Make it easier for people to join deSEC development by improving READMEs and de-complicating setups.",
    "url": "https://github.com/desec-io/desec-stack/projects/7",
    "updated": "2020-05-16T06:57:33Z"
  },
  {
    "name": "Webapp Record Set Management",
    "body": "Extend the DNS management web application to provide a way for users to manage the ressource records of each domain they own, including, but not limited to, A and AAAA records, CNAMEs, TLSA records.",
    "url": "https://github.com/desec-io/desec-stack/projects/8",
    "updated": "2020-05-16T08:20:28Z"
  },
  {
    "name": "Security Housekeeping",
    "body": "Strengthen security measures across the project, including web security for API access and DNSSEC security, by updating to the latest security standards and ciphers.",
    "url": "https://github.com/desec-io/desec-stack/projects/9",
    "updated": "2020-05-16T08:26:46Z"
  }
]
```

Conclusion, for now just plain linking to the GitHub project list has the best value.

Resolves #362 