### PR TITLE
Homepage breaking news about service disruption

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -89,6 +89,33 @@
     </v-app-bar>
 
     <v-content>
+      <v-banner v-for="alert in $store.state.alerts" :key="alert.id">
+        <v-icon
+          slot="icon"
+          color="warning"
+          size="36"
+        >
+          {{ alert.icon }}
+        </v-icon>
+        {{ alert.teaser }}
+        <template v-slot:actions>
+          <v-btn
+            color="primary"
+            text
+            :href="alert.href"
+            v-if="alert.href"
+          >
+            {{ alert.button || 'More' }}
+          </v-btn>
+          <v-btn
+            color="primary"
+            text
+            @click="$store.commit('unalert', alert.id)"
+          >
+            Hide
+          </v-btn>
+        </template>
+      </v-banner>
       <v-progress-linear
               :active="$store.getters.working"
               :indeterminate="$store.getters.working"

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -8,6 +8,7 @@ export default new Vuex.Store({
     authenticated: false,
     token: {},
     work_count: 0,
+    alerts: [],
   },
   mutations: {
     login(state, token) {
@@ -21,9 +22,30 @@ export default new Vuex.Store({
     working(state, working = true) {
       state.work_count += working ? 1 : -1;
     },
+    alert(state, alert) {
+      for (const known_alert of state.alerts) {
+        if (alert.id === known_alert.id) {
+          return;
+        }
+      }
+      state.alerts.push(alert);
+    },
+    unalert(state, id) {
+      let del_idx = undefined;
+      for (const [idx, alert] of state.alerts.entries()) {
+        if (alert.id === id) {
+          del_idx = idx;
+          break;
+        }
+      }
+      if (del_idx !== undefined) {
+        state.alerts.splice(del_idx, 1);
+      }
+    },
   },
   getters: {
-    working: state => !!state.work_count
+    working: state => !!state.work_count,
+    alerts: state => state.alerts,
   },
   actions: {
   },

--- a/webapp/src/views/Home.vue
+++ b/webapp/src/views/Home.vue
@@ -174,8 +174,13 @@ export default {
   },
   created() {
     this.domainType = this.$route.query.domainType || 'none';
+    for (let news of this.breaking_news) {
+      if (new Date() >= news.start && new Date() < news.end) {
+        this.$store.commit('alert', news);
+      }
+    }
   },
-    data: () => ({
+  data: () => ({
     contact_email: process.env.VUE_APP_EMAIL,
     contact_subject: 'Adopting of a Frontend Server',
     contact_body: 'Dear deSEC,\n\nI would like to adopt a frontend server in your networks!',
@@ -357,6 +362,18 @@ export default {
         icon: 'mdi-file-certificate',
         title: "Let's Encrypt Integration",
         text: "We provide easy integration with Let's Encrypt and their certbot tool.",
+      },
+    ],
+    breaking_news: [
+      {
+        id: 'news-20200604001',
+        start: new Date(Date.UTC(2020, 6 - 1, 4)),  // first day of showing
+        end: new Date(Date.UTC(2020, 6 - 1, 7)),  // first day of not showing
+        icon: 'mdi-heart-broken',
+        teaser: 'DNS operations experienced a partial service disruption on June 4, 2020, starting at 12am UTC. ' +
+                'The issue was resolved at 7am UTC.',
+        button: 'Learn More',
+        href: '//talk.desec.io/t/service-disruption-on-june-4-2020/98',
       },
     ],
   })


### PR DESCRIPTION
Adds information about the service disruption today to the home page, and uses the opportunity to introduce an webapp-wide user alerting system that could also be used for error conditions and other important messages.

TODO:

- [x] insert link to detailed service disruption thread