### PR TITLE
fix(api): reduce SOA refresh/retry to 1d for automatic RRSIG rollover

### DIFF
--- a/api/desecapi/pdns_change_tracker.py
+++ b/api/desecapi/pdns_change_tracker.py
@@ -100,12 +100,11 @@ class PDNSChangeTracker:
                         # SOA RRset TTL: 300 (used as TTL for negative replies including NSEC3 records)
                         'ttl': 300,
                         'records': [{
-                            # SOA refresh: 2 weeks (our replication doesn't rely on this, and a high value keeps our
-                            #   frontends from asking all the time)
+                            # SOA refresh: 1 day (only needed for nslord --> nsmaster replication after RRSIG rotation)
                             # SOA retry = refresh
                             # SOA expire: 4 weeks (all signatures will have expired anyways)
                             # SOA minimum: 3600 (for CDS, CDNSKEY, DNSKEY, NSEC3PARAM)
-                            'content': 'set.an.example. get.desec.io. 1 1209600 1209600 2419200 3600',
+                            'content': 'set.an.example. get.desec.io. 1 86400 86400 2419200 3600',
                             'disabled': False
                         }],
                     }],

--- a/api/desecapi/tests/base.py
+++ b/api/desecapi/tests/base.py
@@ -769,7 +769,7 @@ class DesecTestCase(MockPDNSTestCase):
 
     @classmethod
     def requests_desec_domain_creation(cls, name=None):
-        soa_content = 'set.an.example. get.desec.io. 1 1209600 1209600 2419200 3600'
+        soa_content = 'set.an.example. get.desec.io. 1 86400 86400 2419200 3600'
         return [
             cls.request_pdns_zone_create(ns='LORD', payload=soa_content),
             cls.request_pdns_zone_create(ns='MASTER'),


### PR DESCRIPTION
Currently, nsmaster only receives zone updates on record changes,
but not on RRSIG rollovers. This change makes nsmaster ask for
updates once a day.

After this is merged, we need to run the following query on dblord:

```sql
UPDATE records SET content=REPLACE(content, " 1209600 1209600 2419200 3600", " 86400 86400 2419200 3600") WHERE type = "SOA";
```