### PR TITLE
fix(api): fix serializer logic for [] PATCH/PUT payload to rrsets/

### DIFF
--- a/api/desecapi/exceptions.py
+++ b/api/desecapi/exceptions.py
@@ -25,7 +25,8 @@ class PDNSValidationError(ValidationError):
 class PDNSException(APIException):
     def __init__(self, response=None):
         self.response = response
-        return super().__init__(f'pdns response code: {response.status_code}, pdns response body: {response.text}')
+        detail = f'pdns response code: {response.status_code}, body: {response.text}' if response is not None else None
+        return super().__init__(detail)
 
 
 class ConcurrencyException(APIException):

--- a/api/desecapi/pdns_change_tracker.py
+++ b/api/desecapi/pdns_change_tracker.py
@@ -267,7 +267,7 @@ class PDNSChangeTracker:
                 raise e
             except Exception as e:
                 self.transaction.__exit__(type(e), e, e.__traceback__)
-                exc = ValueError(f'For changes {list(map(str, changes))}, {type(e)} occured when applying {change}')
+                exc = ValueError(f'For changes {list(map(str, changes))}, {type(e)} occurred during {change}: {str(e)}')
                 raise exc from e
 
         self.transaction.__exit__(None, None, None)

--- a/api/desecapi/serializers.py
+++ b/api/desecapi/serializers.py
@@ -447,7 +447,7 @@ class RRsetListSerializer(serializers.ListSerializer):
         def is_empty(data_item):
             return data_item.get('records', None) == []
 
-        query = Q()
+        query = Q(pk__in=[])  # start out with an always empty query, see https://stackoverflow.com/q/35893867/6867099
         for item in validated_data:
             query |= Q(type=item['type'], subname=item['subname'])  # validation has ensured these fields exist
         instance = instance.filter(query)
@@ -457,7 +457,7 @@ class RRsetListSerializer(serializers.ListSerializer):
 
         if data_index.keys() | instance_index.keys() != data_index.keys():
             raise ValueError('Given set of known RRsets (`instance`) is not a subset of RRsets referred to in'
-                             '`validated_data`. While this would produce a correct result, this is illegal due to its'
+                             ' `validated_data`. While this would produce a correct result, this is illegal due to its'
                              ' inefficiency.')
 
         everything = instance_index.keys() | data_index.keys()

--- a/api/desecapi/tests/test_rrsets_bulk.py
+++ b/api/desecapi/tests/test_rrsets_bulk.py
@@ -179,6 +179,9 @@ class AuthenticatedRRSetBulkTestCase(AuthenticatedRRSetBaseTestCase):
         response = self.client.bulk_patch_rr_sets(domain_name=self.my_empty_domain.name, payload=[])
         self.assertStatus(response, status.HTTP_200_OK)
 
+        response = self.client.bulk_patch_rr_sets(domain_name=self.my_rr_set_domain.name, payload=[])
+        self.assertStatus(response, status.HTTP_200_OK)
+
     def test_bulk_patch_does_not_accept_empty_payload(self):
         response = self.client.bulk_patch_rr_sets(domain_name=self.my_empty_domain.name, payload=None)
         self.assertContains(response, 'No data provided', status_code=status.HTTP_400_BAD_REQUEST)
@@ -327,6 +330,8 @@ class AuthenticatedRRSetBulkTestCase(AuthenticatedRRSetBaseTestCase):
 
     def test_bulk_put_does_accept_empty_list(self):
         response = self.client.bulk_put_rr_sets(domain_name=self.my_empty_domain.name, payload=[])
+        self.assertStatus(response, status.HTTP_200_OK)
+        response = self.client.bulk_put_rr_sets(domain_name=self.my_rr_set_domain.name, payload=[])
         self.assertStatus(response, status.HTTP_200_OK)
 
     def test_bulk_put_does_not_accept_empty_payload(self):


### PR DESCRIPTION
This fixes an uncaught exception when processing `[]` via PUT or PATCH on the `rrsets/` endpoint of a domain that already has at least one RRset configured.

The bug was the following: The serializer fetches the to-be-modified RRset instances from the database by adding (`|`-ing) a Django `Q()` object for each of the RRsets given in the payload, starting out from an empty `Q()` object. If the given list of RRsets is empty, the query is just `Q()`, which filters nothing, and all RRsets are retrieved. Instead, no RRsets should be retrieved. This is now ensured by making sure we start out with a queryset that's always empty, and then `|=` the other RRsets.