### PR TITLE
Update Terms of Use

### DIFF
--- a/webapp/src/views/Terms.vue
+++ b/webapp/src/views/Terms.vue
@@ -81,9 +81,7 @@ export default {
         title: 'Expiration of Inactive dynDNS Domains',
         text: 'Dynamic DNS domains that are not updated for six months or longer will be ' +
                 'deleted after a warning with 4 weeks notice. Owners can prevent deletion by updating DNS ' +
-                'information. Deleted domains will undergo retention until associated certificates as recorded in ' +
-                'the transparency log have expired, to make sure no valid certificates exist when another user ' +
-                'registers the name again.',
+                'information.',
       },
       {
         title: 'Domains with Illegal Activity',

--- a/webapp/src/views/Terms.vue
+++ b/webapp/src/views/Terms.vue
@@ -32,7 +32,7 @@
         <v-col class="col-12 col-sm-6 d-flex" v-for="(t, idx) in terms_of_use" :key="t.title">
           <v-card>
             <v-card-title>§{{idx+1}} {{t.title}}</v-card-title>
-            <v-card-text>{{t.text}}</v-card-text>
+            <v-card-text v-html="t.text" />
           </v-card>
         </v-col>
       </v-row>
@@ -82,6 +82,17 @@ export default {
         text: 'Dynamic DNS domains that are not updated for six months or longer will be ' +
                 'deleted after a warning with 4 weeks notice. Owners can prevent deletion by updating DNS ' +
                 'information.',
+      },
+      {
+        title: 'Secure Delegation Required',
+        text: 'Domains created at deSEC which do not include deSEC\'s nameservers in their set of authoritative ' +
+            'nameservers ("NS records") or which fail to establish a DNSSEC chain of trust may receive a deletion ' +
+            'warning and may be deleted four weeks thereafter if that condition still applies. <br/>' +
+            'Anyone who can prove ownership of a domain name by an upstream registry may claim control over this ' +
+            'domain at all deSEC nameservers, even if a corresponding deSEC zone has been created by another user. ' +
+            'During the transfer of control, the zone\'s DNS information and signing keys will be deleted; a backup ' +
+            'of the zone\'s record sets will be made available to the user account that previously held the domain ' +
+            'at deSEC.',
       },
       {
         title: 'Domains with Illegal Activity',

--- a/webapp/src/views/Terms.vue
+++ b/webapp/src/views/Terms.vue
@@ -29,9 +29,9 @@
         </v-col>
       </v-row>
       <v-row class="pb-8">
-        <v-col class="col-12 col-sm-6 d-flex" v-for="t in terms_of_use" :key="t.title">
+        <v-col class="col-12 col-sm-6 d-flex" v-for="(t, idx) in terms_of_use" :key="t.title">
           <v-card>
-            <v-card-title v-text="t.title"></v-card-title>
+            <v-card-title>§{{idx+1}} {{t.title}}</v-card-title>
             <v-card-text>{{t.text}}</v-card-text>
           </v-card>
         </v-col>
@@ -65,20 +65,20 @@ export default {
   data: () => ({
     terms_of_use: [
       {
-        title: '§1 Keep Server Load Low',
+        title: 'Keep Server Load Low',
         text: 'Only send update requests when there is something to update, and use reasonable TTLs. Accounts ' +
                 'that cause extraordinarily high load or cost may be disabled or throttled. Account ' +
                 'holders will be asked for cooperation to resolve the issue.',
       },
       {
-        title: '§2 Users Must be Responsive',
+        title: 'Users Must be Responsive',
         text: 'Users are required to register with an email address and are obliged to read and react to our ' +
                 'emails. For users who do not react or are uncooperative, deSEC reserves the right to disable the ' +
                 'account and/or zone, and/or modify or disable DNS records or zones in order to ensure smooth ' +
                 'operation of deSEC services.',
       },
       {
-        title: '§3 Expiration of Inactive dynDNS Domains',
+        title: 'Expiration of Inactive dynDNS Domains',
         text: 'Dynamic DNS domains that are not updated for six months or longer will be ' +
                 'deleted after a warning with 4 weeks notice. Owners can prevent deletion by updating DNS ' +
                 'information. Deleted domains will undergo retention until associated certificates as recorded in ' +
@@ -86,27 +86,27 @@ export default {
                 'registers the name again.',
       },
       {
-        title: '§4 Domains with Illegal Activity',
+        title: 'Domains with Illegal Activity',
         text: 'Domains that are used for illegal activity such as spam, scam, malware, phishing, etc. will be ' +
                 'disabled immediately and permanently, and owners will be held liable. deSEC will cooperate with ' +
                 'law enforcement to assist prosecution of illegal activity. In most cases, German and European Union ' +
                 'legislation will apply.',
       },
       {
-        title: '§5 Clients Will Need Updates',
+        title: 'Clients Will Need Updates',
         text: 'In order to ensure surpassing security and usability, deSEC will keep the provided services up to ' +
                 'date as technology evolves. We explicitly do not guarantee that old client software keeps on ' +
                 'working forever. Breaking changes will usually be announced weeks ahead, but time-critical changes ' +
                 'may come with a shorter or even no grace period.',
       },
       {
-        title: '§6 No Warranty',
+        title: 'No Warranty',
         text: 'deSEC does not guarantee availability for its free services. Functionality of all services is ' +
                 'provided on a best-effort basis. In particular, Quality of Service, even on a low level, and ' +
                 'fitness for a particular purpose are not assured.',
       },
       {
-        title: '§7 Fineprint',
+        title: 'Fineprint',
         text: 'If a provision of this agreement is or becomes legally invalid or if there is any gap that needs to ' +
                 'be filled, the validity of the remainder of the agreement shall not be affected thereby. Invalid ' +
                 'provisions shall be replaced by common consent with such provisions which come as close as possible ' +


### PR DESCRIPTION
This modifies the Terms of Use to

1. remove mention of any retention period for deleted domains (as it is currently not implemented)
1. adds the requirement that domains must be delegated securely (but leaves the operators to choose if domains that are not delegated / not securely delegated will be deleted)