### PR TITLE
fix(api): pin amqp version that otherwise breaks Celery

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -17,3 +17,4 @@ pylibmc~=1.6.1
 pyyaml~=5.3.1
 requests~=2.25.0
 uwsgi~=2.0.0
+amqp==5.0.3


### PR DESCRIPTION
confirmed broken is amqp==5.0.5 of 28 Jan 2021.

How do we proceed with this?