### PR TITLE
20210216 arbitrary dyn updates

### DIFF
--- a/api/desecapi/authentication.py
+++ b/api/desecapi/authentication.py
@@ -94,8 +94,7 @@ class BasicTokenAuthentication(BaseAuthentication):
         try:
             username, key = base64.b64decode(basic).decode(HTTP_HEADER_ENCODING).split(':')
             user, token = TokenAuthentication().authenticate_credentials(key)
-            domain_names = user.domains.values_list('name', flat=True)
-            if username not in ['', user.email] and not username.lower() in domain_names:
+            if username not in ['', user.email] and not user.domains.filter(name=username.lower()).exists():
                 raise Exception
         except Exception:
             raise exceptions.AuthenticationFailed(invalid_token_message)

--- a/api/desecapi/management/commands/chores.py
+++ b/api/desecapi/management/commands/chores.py
@@ -43,7 +43,8 @@ class Command(BaseCommand):
             'ttl': '3600',
             'records': [content]
         }]
-        serializer = serializers.RRsetSerializer(instances, domain=domain, data=data, many=True, partial=True)
+        context = {'domain': domain}
+        serializer = serializers.RRsetSerializer(instances, data=data, many=True, partial=True, context=context)
         serializer.is_valid(raise_exception=True)
         with PDNSChangeTracker():
             serializer.save()

--- a/api/desecapi/metrics.py
+++ b/api/desecapi/metrics.py
@@ -45,6 +45,3 @@ set_counter('desecapi_pdns_catalog_updated', 'number of times pdns catalog was u
 
 # throttling.py metrics
 set_counter('desecapi_throttle_failure', 'number of requests throttled', ['method', 'scope', 'user'])
-
-# serializers.py metrics
-set_counter('desecapi_rrset_list_serializer', 'number of times RRsetListSerializer was initialized')

--- a/api/desecapi/serializers.py
+++ b/api/desecapi/serializers.py
@@ -426,12 +426,13 @@ class RRsetSerializer(ConditionalExistenceModelSerializer):
             self.domain = self.context['domain']
         except KeyError:
             raise ValueError('RRsetSerializer() must be given a domain object (to validate uniqueness constraints).')
+        self.minimum_ttl = self.context.get('minimum_ttl', self.domain.minimum_ttl)
 
     def get_fields(self):
         fields = super().get_fields()
         fields['subname'].validators.append(ReadOnlyOnUpdateValidator())
         fields['type'].validators.append(ReadOnlyOnUpdateValidator())
-        fields['ttl'].validators.append(MinValueValidator(limit_value=self.domain.minimum_ttl))
+        fields['ttl'].validators.append(MinValueValidator(limit_value=self.minimum_ttl))
         return fields
 
     def get_validators(self):

--- a/api/desecapi/views.py
+++ b/api/desecapi/views.py
@@ -364,14 +364,11 @@ class DynDNS12Update(APIView):
         ]
 
         instances = domain.rrset_set.filter(subname='', type__in=['A', 'AAAA']).all()
-        context = {'domain': domain}
+        context = {'domain': domain, 'minimum_ttl': 60}
         serializer = serializers.RRsetSerializer(instances, data=data, many=True, partial=True, context=context)
         try:
             serializer.is_valid(raise_exception=True)
         except ValidationError as e:
-            if any('ttl' in error for error in e.detail):
-                raise PermissionDenied({'detail': 'Domain not eligible for dynamic updates, please contact support.'})
-
             if any(
                     any(
                         getattr(non_field_error, 'code', '') == 'unique'

--- a/docs/dyndns/update-api.rst
+++ b/docs/dyndns/update-api.rst
@@ -11,17 +11,23 @@ Please note that when using HTTPS (which we highly recommend), outdated setups
 issues, you may have to update your dynDNS client and/or libraries used by it
 (such as OpenSSL).
 
+**Note:** Out of mercy for legacy clients (especially old routers), we still
+accept unencrypted requests for this service.  We **urge** you to **use HTTPS
+whenever possible**.
+
 Update Request
 ``````````````
-An IP updates is performed by sending a GET request to ``update.dedyn.io`` via
-HTTP or HTTPS. The path component can be chosen freely as long as it does not
-end in ``.ico`` or ``.png``.
+An IP updates is performed by sending a ``GET`` request to ``update.dedyn.io``
+via IPv4 or IPv6.  To enforce IPv6, use ``update6.dedyn.io``.  The path
+component can be chosen freely as long as it does not end in ``.ico`` or
+``.png``.  HTTPS is recommended over HTTP.
 
-You can connect via IPv4 or IPv6. To enforce IPv6, use ``update6.dedyn.io``.
+When the request is authenticated successfully, we use the connection IP
+address and query parameters to update your domain's DNS ``A`` (IPv4) and
+``AAAA`` (IPv6) records.  The new records will have a TTL value of 60 seconds
+(that is, outdated values should disappear from DNS resolvers within that
+time).
 
-Please be aware that while we still accept unencrypted requests, we **urge**
-you to use HTTPS. For that reason, we also send an HSTS header on HTTPS
-connections.
 
 .. _update-api-authentication:
 
@@ -78,10 +84,7 @@ determine the hostname, we try the following steps until there is a match:
   associated with your user account (if not ambiguous).
 
 If we cannot determine a hostname to update, the API will return a ``404 Not
-Found`` status code. If the selected hostname is not eligible for dynamic
-updates, we will return ``403 Forbidden``. This usually happens if you try
-updating a hostname that is not under the ``dedyn.io`` domain. If you are
-affected by this and would like to use another domain, please contact support.
+Found`` status code.
 
 .. _determine-ip-addresses:
 
@@ -118,8 +121,8 @@ Examples
 ````````
 The examples below use ``<your domain>.dedyn.io`` as the domain which is to be updated and
 ``<your authorization token>`` as an API token affiliated with the respective account.
-(See :ref:`manage-tokens` for details.) ``<1.2.3.4>`` is used as an example for an IPv4 Address,
-``<fd08::1234>`` as a standin for an IPv6 address. Replace those (including the ``<`` and ``>``)
+(See :ref:`manage-tokens` for details.) ``1.2.3.4`` is used as an example for an IPv4 Address,
+``fd08::1234`` as a stand-in for an IPv6 address. Replace those (including the ``<`` and ``>``)
 with your respective values.
 
 


### PR DESCRIPTION
As people ask about it very often, this PR enables using the dynDNS update endpoints regardless of the domain's `minimum_ttl`. The only reason not to do that would load on the secondaries. Once that becomes a problem, we can revisit. (I don't really think it will be an issue.) I went for the "just works" approach, as opposed to adding GUI functionality to change the minimum TTL.

So far, there is no documentation. I'm not sure if there should be (it would encourage such use).

I am also planning to tackle #412 in this PR.