### PR TITLE
fix(api): properly return mandate reference for donations, fixes #530

### DIFF
--- a/api/desecapi/serializers.py
+++ b/api/desecapi/serializers.py
@@ -601,6 +601,9 @@ class DonationSerializer(serializers.ModelSerializer):
     def validate_iban(value):
         return re.sub(r'[\s]', '', value)
 
+    def create(self, validated_data):
+        return self.Meta.model(**validated_data)
+
 
 class UserSerializer(serializers.ModelSerializer):
 

--- a/api/desecapi/views.py
+++ b/api/desecapi/views.py
@@ -391,7 +391,7 @@ class DonationList(generics.CreateAPIView):
     serializer_class = serializers.DonationSerializer
 
     def perform_create(self, serializer):
-        instance = self.serializer_class.Meta.model(**serializer.validated_data)
+        instance = serializer.save()
 
         context = {
             'donation': instance,


### PR DESCRIPTION
The response is generated from serializer.data, which is based on only
request data until .save() is called.  After that, is contains a
representation of the instance created during the .save() call.

This commit moves the instance creation from the view to the .save()
call so that the .data logistics works properly (without actually
saving anything).