### PR TITLE
fix(gitzones): unlock git user to allow ssh-login using pubkey

### DIFF
--- a/gitzones/Dockerfile
+++ b/gitzones/Dockerfile
@@ -4,7 +4,8 @@ RUN apk add --no-cache openssh git python3
 
 RUN adduser -D -s /usr/bin/git-shell git \
   && mkdir /home/git/.ssh \
-  && ln -s /etc/ssh/keys/git_authorized_keys /home/git/.ssh/authorized_keys
+  && ln -s /etc/ssh/keys/git_authorized_keys /home/git/.ssh/authorized_keys \
+  && passwd -u git  # sshd config prohibits passwordless login
 
 COPY git-shell-commands /home/git/
 COPY sshd_config /etc/ssh/


### PR DESCRIPTION
This does not allow login using any password.