### PR TITLE
fix(api): don't use Celery 5.0.6 (broken)

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,5 +1,5 @@
 captcha~=0.3.0
-celery~=5.0.2
+celery~=5.0.2,!=5.0.6
 coverage~=5.5
 cryptography~=3.4.7
 Django~=3.1.0


### PR DESCRIPTION
due to https://github.com/celery/celery/issues/6829

Celery 5.0.6 release has been retracted from GitHub, but not from PyPI. Today's deployment of #547 thus caused deployment of the broken version. 

The impact is unknown (it appears that sign-up emails are delivered).

Lesson: Wait for post-merge CI to succeed before deploying.