### PR TITLE
Clarify documentation for IP update API

### DIFF
--- a/docs/dyndns/configure.rst
+++ b/docs/dyndns/configure.rst
@@ -2,8 +2,9 @@ Configuring your dynDNS Client
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Here's how to configure your client to send your IP address to our servers so
-that we can publish it in the DNS. Depending on your use case, one of the
-following options might be easier than the others.
+that we can publish it in the DNS. This works with both your own domains and
+with dynDNS domains registered with us under dedyn.io. Depending on your use
+case, one of the following options might be easier than the others.
 
 To update your dynDNS IP address, there are several options:
 
@@ -72,8 +73,8 @@ Field                           Entry
 =============================   =====
 DynDNS Provider                 User-defined
 Update URL :superscript:`1`     ``https://update.dedyn.io/?myipv4=<ipaddr>&myipv6=<ip6addr>``
-Domain Name                     <your domain>.dedyn.io
-Username :superscript:`2`       <your domain>.dedyn.io
+Domain Name                     <your domain>
+Username :superscript:`2`       <your domain>
 Password :superscript:`3`       <your authorization token>
 =============================   =====
 
@@ -85,8 +86,9 @@ Password :superscript:`3`       <your authorization token>
   authentication which is more secure (see :ref:`update-api-authentication`).
 
 *Note 2*
-  **Not** your deSEC username! Instead, use the domain you want to update,
-  see :ref:`update-api-authentication` for details.
+  **Not** your deSEC username! Instead, use the domain you want to update, for
+  example ``yourdomain.dedyn.io``. See :ref:`update-api-authentication` for
+  details.
 
 *Note 3*
   A valid access token for the domain. **Not** you deSEC account password!

--- a/docs/dyndns/update-api.rst
+++ b/docs/dyndns/update-api.rst
@@ -131,25 +131,26 @@ dynDNS updates are subject to rate limiting.  For details, see
 
 Examples
 ````````
-The examples below use ``<your domain>`` (e.g. ``example.dedyn.io``) as the
-domain which is to be updated and ``<your authorization token>`` as an API
-token affiliated with the respective account (see :ref:`manage-tokens` for
-details.)  ``1.2.3.4`` is used as an example IPv4 address, and ``fd08::1234``
-for IPv6.  Replace those (including the ``<`` and ``>``) with your respective
-values.
+The examples below use ``<your domain>`` as the domain which is to be updated
+(which could be a custom domain or a dedyn.io domain like
+``yourdomain.dedyn.io``) and ``<your authorization token>`` as an API token
+affiliated with the respective account (see :ref:`manage-tokens` for details.)
+``1.2.3.4`` is used as an example for an IPv4 address, ``fd08::1234`` as a
+stand-in for an IPv6 address. Replace those (including the ``<`` and ``>``)
+with your respective values.
 
 
 Basic authentication with automatic IP detection (IPv4 **or** IPv6)::
 
   curl --user <your domain>:<your authorization token> https://update.dedyn.io/
-  
+
   curl https://update.dedyn.io/?hostname=<your domain> \
     --header "Authorization: Token <your authorization token>"
 
 Basic authentication with forced use of IPv6 (will remove IPv4 address from the DNS)::
 
   curl --user <your domain>:<your authorization token> https://update6.dedyn.io/
-  
+
   curl https://update6.dedyn.io/?hostname=<your domain> \
     --header "Authorization: Token <your authorization token>"
 
@@ -160,4 +161,3 @@ Basic authentication with simultaneous update of IPv4 and IPv6::
 
   curl "https://update6.dedyn.io/?hostname=<your domain>?myipv4=1.2.3.4&myipv6=fd08::1234" \
     --header "Authorization: Token <your authorization token>"
-


### PR DESCRIPTION
When I read the documentation for the IP update API, I understood it as something that only works with dedyn.io domains.

I think these changes would make it clearer that they work with a normal deSEC account with any domain, while hopefully not making it less clear that it works with deDyn domains.