### PR TITLE
feat(api): support DS delete algorithm (RFC 8078)

### DIFF
--- a/api/desecapi/dns.py
+++ b/api/desecapi/dns.py
@@ -71,7 +71,8 @@ class LongQuotedTXT(dns.rdtypes.txtbase.TXTBase):
 
 # TODO remove when https://github.com/rthalley/dnspython/pull/625 is in the main codebase
 class _DigestLengthMixin:
-    _digest_length_by_type = {
+    _digest_length_by_type = {  # octets (not hex)
+        0: 1,  # reserved in RFC 3658 Sec. 2.4, but used in RFC 8078 Sec. 4 (DS delete via CDS)
         1: 20,  # SHA-1, RFC 3658 Sec. 2.4
         2: 32,  # SHA-256, RFC 4509 Sec. 2.2
         3: 32,  # GOST R 34.11-94, RFC 5933 Sec. 4 in conjunction with RFC 4490 Sec. 2.1
@@ -82,13 +83,12 @@ class _DigestLengthMixin:
         super().__init__(*args, **kwargs)
 
         try:
-            if self.digest_type == 0:  # reserved, RFC 3658 Sec. 2.4
-                raise ValueError('digest type 0 is reserved')
-            expected_length = _DigestLengthMixin._digest_length_by_type[self.digest_type]
+            expected_len = _DigestLengthMixin._digest_length_by_type[self.digest_type]
         except KeyError:
             raise ValueError('unknown digest type')
-        if len(self.digest) != expected_length:
-            raise ValueError('digest length inconsistent with digest type')
+        actual_len = len(self.digest)
+        if actual_len != expected_len:
+            raise ValueError(f'invalid digest length {actual_len*2} (expected for this digest type: {expected_len*2}')
 
 
 @dns.immutable.immutable

--- a/api/desecapi/tests/test_rrsets.py
+++ b/api/desecapi/tests/test_rrsets.py
@@ -368,8 +368,10 @@ class AuthenticatedRRSetTestCase(AuthenticatedRRSetBaseTestCase):
                         '257 3 8 AwEAAcw5QLr0IjC0wKbGoBPQv4qmeqHy9mvL5qGQTuaG5TSrNqEAR6b/qvxDx6my4JmEmjUPA1JeEI9YfTUieMr2UZflu7aIbZFLw0vqiYrywCGrCHXLalOrEOmrvAxLvq4vHtuTlH7JIszzYBSes8g1vle6KG7xXiP3U5Ll96Qiu6bZ31rlMQSPB20xbqJJh6psNSrQs41QvdcXAej+K2Hl1Wd8kPriec4AgiBEh8sk5Pp8W9ROLQ7PcbqqttFaW2m7N/Wy4qcFU13roWKDEAstbxH5CHPoBfZSbIwK4KM6BK/uDHpSPIbiOvOCW+lvu9TAiZPc0oysY6aslO7jXv16Gws=')),
             ('CDNSKEY', ('257 3 13 aCoEWYBBVsP9Fek2oC8yqU8ocKmnS1iDSFZNORnQuHKtJ9Wpyz+kNryq uB78Pyk/NTEoai5bxoipVQQXzHlzyg==',
                         '257 3 13 aCoEWYBBVsP9Fek2oC8yqU8ocKmnS1iDSFZNORnQuHKtJ9Wpyz+kNryquB78Pyk/NTEoai5bxoipVQQXzHlzyg==')),
+            ('CDNSKEY', ('0 3 0 AA==', '0 3 0 AA==')),
             ('CDS', ('047883  013  02  43BD262211B2A748335149408F67BC95B9A4A3174FD86E6A83830380 446E7AFD',
                      '47883 13 2 43BD262211B2A748335149408F67BC95B9A4A3174FD86E6A83830380446E7AFD'.lower())),
+            ('CDS', ('0 0 0 00', '0 0 0 00')),
             ('CERT', ('06 00 00 sadfdd==', '6 0 0 sadfdQ==')),
             ('CNAME', ('EXAMPLE.COM.', 'example.com.')),
             ('CSYNC', ('066 03  NS  AAAA A', '66 3 A NS AAAA')),
@@ -585,7 +587,8 @@ class AuthenticatedRRSetTestCase(AuthenticatedRRSetBaseTestCase):
                 'a 3 13 aCoEWYBBVsP9Fek2oC8yqU8ocKmnS1iDSFZNORnQuHKtJ9Wpyz+kNryq uB78Pyk/NTEoai5bxoipVQQXzHlzyg=='
                 '257 b 13 aCoEWYBBVsP9Fek2oC8yqU8ocKmnS1iDSFZNORnQuHKtJ9Wpyz+kNryq uB78Pyk/NTEoai5bxoipVQQXzHlzyg=='
                 '257 3 c aCoEWYBBVsP9Fek2oC8yqU8ocKmnS1iDSFZNORnQuHKtJ9Wpyz+kNryq uB78Pyk/NTEoai5bxoipVQQXzHlzyg=='
-                '257 3 13 d'
+                '257 3 13 d',
+                '0 3 0 0',
             ],
             'CDS': [
                 'a 8 1 24396E17E36D031F71C354B06A979A67A01F503E',
@@ -596,6 +599,7 @@ class AuthenticatedRRSetTestCase(AuthenticatedRRSetBaseTestCase):
                 '6454 8 0 24396E17E36D031F71C354B06A979A67A01F503E',
                 '6454 8 5 24396E17E36D031F71C354B06A979A67A01F503E',
                 '6454 8 1 aabbccddeeff',
+                '0 0 0 0',
             ],
             'CNAME': ['example.com', '10 example.com.'],
             'CSYNC': ['0 -1 A', '444 65536 A', '0 3 AAA'],

--- a/docs/dyndns/configure.rst
+++ b/docs/dyndns/configure.rst
@@ -152,9 +152,11 @@ documentation.
   assign to your domain.  So, if you connect via IPv6, this address will be
   set on your domain, *even if you did not provide it explicitly*.
 
-  If you would like to *avoid* setting an IPv6 address automatically, one
-  simple workaround is to add a fake parameter on the domain section like
-  this: ``mydomain.dedyn.io&myipv6=``
+  If you would like to *avoid* setting an IPv6 address automatically, and
+  instead configure an address statically (or remove the address), you can add
+  a the ``myipv6`` parameter on the domain section, like this:
+  ``mydomain.dedyn.io&myipv6=`` (delete) or ``mydomain.dedyn.io&myipv6=::1``
+  (static value)
 
 To test your setup, run ``sudo ddclient -force`` and see if everything works as
 expected.

--- a/test/e2e2/spec/test_api_rr.py
+++ b/test/e2e2/spec/test_api_rr.py
@@ -33,10 +33,12 @@ VALID_RECORDS_CANONICAL = {
         '256 3 8 AwEAAday3UX323uVzQqtOMQ7EHQYfD5O fv4akjQGN2zY5AgB/2jmdR/+1PvXFqzK CAGJv4wjABEBNWLLFm7ew1hHMDZEKVL1 7aml0EBKI6Dsz6Mxt6n7ScvLtHaFRKax T4i2JxiuVhKdQR9XGMiWAPQKrRM5SLG0 P+2F+TLKl3D0L/cD',
         '257 3 8 AwEAAcw5QLr0IjC0wKbGoBPQv4qmeqHy 9mvL5qGQTuaG5TSrNqEAR6b/qvxDx6my 4JmEmjUPA1JeEI9YfTUieMr2UZflu7aI bZFLw0vqiYrywCGrCHXLalOrEOmrvAxL vq4vHtuTlH7JIszzYBSes8g1vle6KG7x XiP3U5Ll96Qiu6bZ31rlMQSPB20xbqJJ h6psNSrQs41QvdcXAej+K2Hl1Wd8kPri ec4AgiBEh8sk5Pp8W9ROLQ7PcbqqttFa W2m7N/Wy4qcFU13roWKDEAstbxH5CHPo BfZSbIwK4KM6BK/uDHpSPIbiOvOCW+lv u9TAiZPc0oysY6aslO7jXv16Gws=',
         '257 3 13 aCoEWYBBVsP9Fek2oC8yqU8ocKmnS1iD SFZNORnQuHKtJ9Wpyz+kNryquB78Pyk/ NTEoai5bxoipVQQXzHlzyg==',
+        '0 3 0 AA==',
     ],
     'CDS': [
         None,
         '6454 8 1 24396e17e36d031f71c354b06a979a67a01f503e',
+        '0 0 0 00',
     ],
     'CERT': ['6 0 0 sadfdQ=='],
     'CNAME': ['example.com.'],
@@ -296,10 +298,14 @@ INVALID_RECORDS = {
         '2:::/129',
     ],
     'CAA': ['43235 issue "letsencrypt.org"'],
-    'CDNSKEY': ['a 3 13 aCoEWYBBVsP9Fek2oC8yqU8ocKmnS1iDSFZNORnQuHKtJ9Wpyz+kNryq uB78Pyk/NTEoai5bxoipVQQXzHlzyg=='],
+    'CDNSKEY': [
+        'a 3 13 aCoEWYBBVsP9Fek2oC8yqU8ocKmnS1iDSFZNORnQuHKtJ9Wpyz+kNryq uB78Pyk/NTEoai5bxoipVQQXzHlzyg==',
+        '0 3 0 0',
+    ],
     'CDS': [
         'a 8 1 24396E17E36D031F71C354B06A979A67A01F503E',
         '6454 8 1 aabbccddeeff',
+        '0 0 0 0',
     ],
     'CERT': ['6 0 sadfdd=='],
     'CNAME': ['example.com', '10 example.com.'],


### PR DESCRIPTION
This will be needed once there is a protocol for authenticated bootstrapping of DNSSEC delegations, e.g. for people who need to unsecure there delegation before moving to a non-DNSSEC provider.

If we don't support signaling "DS delete" via CDS/CDNSKEY, the zone owner could still delete the DS records via the registrar/registry, but there's no guarantee that the bootstrapping protocol won't add them back in.

Related: https://github.com/PowerDNS/pdns/issues/10608