### PR TITLE
fix(api): enforce (non-)apex requirements from DNSKEY, DS

### DIFF
--- a/api/desecapi/models.py
+++ b/api/desecapi/models.py
@@ -209,7 +209,7 @@ validate_domain_name = [
 class DomainManager(Manager):
     def filter_qname(self, qname: str, **kwargs) -> models.query.QuerySet:
         try:
-            Domain._meta.get_field('name').run_validators(qname.removeprefix('*.'))
+            Domain._meta.get_field('name').run_validators(qname.removeprefix('*.').lower())
         except ValidationError:
             raise ValueError
         return self.annotate(

--- a/api/desecapi/models.py
+++ b/api/desecapi/models.py
@@ -710,9 +710,13 @@ class RRset(ExportModelOperationsMixin('RRset'), models.Model):
                 errors.append(f'{self.type} RRset cannot have multiple records.')
 
         # Non-apex
-        if self.type == 'CNAME':
+        if self.type in ('CNAME', 'DS',):
             if self.subname == '':
-                errors.append('CNAME RRset cannot have empty subname.')
+                errors.append(f'{self.type} RRset cannot have empty subname.')
+
+        if self.type in ('DNSKEY',):
+            if self.subname != '':
+                errors.append(f'{self.type} RRset must have empty subname.')
 
         def _error_msg(record, detail):
             return f'Record content of {self.type} {self.name} invalid: \'{record}\': {detail}'

--- a/api/desecapi/tests/test_domains.py
+++ b/api/desecapi/tests/test_domains.py
@@ -225,7 +225,7 @@ class DomainOwnerTestCase1(DomainOwnerTestCase):
             domain.save()
 
         for domain in domains:
-            for name in [domain.name, f'foo.bar.{domain.name}']:
+            for name in [domain.name, f'foo.bar.{domain.name}', f'foo.BAR.{domain.name}']:
                 response = self.client.get(self.reverse('v1:domain-list'), data={'owns_qname': name})
                 self.assertStatus(response, status.HTTP_200_OK)
                 self.assertEqual(len(response.data), 1)


### PR DESCRIPTION
Related: https://github.com/PowerDNS/pdns/pull/10959

This we deployed PowerDNS 4.6.0, non-compliant RRsets are rejected by pdns. Let's reject them earlier to get a better error message.