### PR TITLE
Introduce Management Command for Abuse Cases

### DIFF
--- a/api/desecapi/management/commands/stop-abuse.py
+++ b/api/desecapi/management/commands/stop-abuse.py
@@ -1,0 +1,21 @@
+from django.core.management import BaseCommand
+
+from desecapi.models import RRset, Domain, User
+from desecapi.pdns_change_tracker import PDNSChangeTracker
+
+
+class Command(BaseCommand):
+    help = 'Removes all DNS records from the given domain and suspends the associated user'
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain-name', nargs='*', help='Domain(s) to remove all DNS records from')
+
+    def handle(self, *args, **options):
+        with PDNSChangeTracker():
+            domains = Domain.objects.filter(name__in=options['domain-name'])
+            users = User.objects.filter(domains__name__in=options['domain-name'])
+            rrsets = RRset.objects.filter(domain__name__in=options['domain-name']).exclude(type='NS', subname='')
+            print(f'Deleting {rrsets.count()} RRset(s) from {domains.count()} domain(s); '
+                  f'disabling {users.count()} associated user account(s).')
+            rrsets.delete()
+        users.update(is_active=False)

--- a/api/desecapi/management/commands/stop-abuse.py
+++ b/api/desecapi/management/commands/stop-abuse.py
@@ -1,21 +1,46 @@
 from django.core.management import BaseCommand
+from django.db.models import Q
 
+from api import settings
 from desecapi.models import RRset, Domain, User
 from desecapi.pdns_change_tracker import PDNSChangeTracker
 
 
 class Command(BaseCommand):
-    help = 'Removes all DNS records from the given domain and suspends the associated user'
+    help = 'Removes all DNS records from domains given either by name or by email address of their owner. ' \
+           'Locks all implicated user accounts.'
 
     def add_arguments(self, parser):
-        parser.add_argument('domain-name', nargs='*', help='Domain(s) to remove all DNS records from')
+        parser.add_argument('names', nargs='*',
+                            help='Domain(s) and User(s) to truncate and disable identified by name and email addresses')
 
     def handle(self, *args, **options):
         with PDNSChangeTracker():
-            domains = Domain.objects.filter(name__in=options['domain-name'])
-            users = User.objects.filter(domains__name__in=options['domain-name'])
-            rrsets = RRset.objects.filter(domain__name__in=options['domain-name']).exclude(type='NS', subname='')
+            # domains to truncate: all domains given and all domains belonging to a user given
+            domains = Domain.objects.filter(
+                Q(name__in=options['names']) |
+                Q(owner__email__in=options['names'])
+            )
+
+            # users to lock: all associated with any of the domains and all given
+            users = User.objects.filter(
+                Q(domains__name__in=options['names']) |
+                Q(email__in=options['names'])
+            )
+
+            # rrsets to delete: all belonging to (all domains given and all domains belonging to a user given)
+            rrsets = RRset.objects.filter(
+                Q(domain__name__in=options['names']) |
+                Q(domain__owner__email__in=options['names'])
+            )
+
             print(f'Deleting {rrsets.count()} RRset(s) from {domains.count()} domain(s); '
                   f'disabling {users.count()} associated user account(s).')
+
+            # delete rrsets and create default NS records
             rrsets.delete()
+            for d in domains:
+                RRset.objects.create(domain=d, subname='', type='NS', ttl=3600, contents=settings.DEFAULT_NS)
+
+        # lock users
         users.update(is_active=False)

--- a/api/desecapi/tests/test_stop_abuse.py
+++ b/api/desecapi/tests/test_stop_abuse.py
@@ -1,0 +1,57 @@
+from django.core import management
+
+from desecapi import models
+from desecapi.tests.base import DomainOwnerTestCase
+
+
+class StopAbuseCommandTest(DomainOwnerTestCase):
+
+    @classmethod
+    def setUpTestDataWithPdns(cls):
+        super().setUpTestDataWithPdns()
+        cls.create_rr_set(cls.my_domains[1], ['127.0.0.1', '127.0.1.1'], type='A', ttl=123)
+        cls.create_rr_set(cls.other_domains[1], ['40.1.1.1', '40.2.2.2'], type='A', ttl=456)
+        for d in cls.my_domains + cls.other_domains:
+            cls.create_rr_set(d, ['ns1.example.', 'ns2.example.'], type='NS', ttl=456)
+            cls.create_rr_set(d, ['ns1.example.', 'ns2.example.'], type='NS', ttl=456, subname='subname')
+            cls.create_rr_set(d, ['"foo"'], type='TXT', ttl=456)
+
+    def test_noop(self):
+        # test implicit by absence assertPdnsRequests
+        management.call_command('stop-abuse')
+
+    def test_remove_rrsets(self):
+        with self.assertPdnsRequests(self.requests_desec_rr_sets_update(name=self.my_domain.name)):
+            management.call_command('stop-abuse', self.my_domain)
+        self.assertEqual(models.RRset.objects.filter(domain__name=self.my_domain.name).count(), 1)  # only NS left
+
+    def test_disable_user(self):
+        with self.assertPdnsRequests(self.requests_desec_rr_sets_update(name=self.my_domain.name)):
+            management.call_command('stop-abuse', self.my_domain)
+        self.owner.refresh_from_db()
+        self.assertEqual(self.owner.is_active, False)
+
+    def test_keep_other_owned_domains(self):
+        with self.assertPdnsRequests(self.requests_desec_rr_sets_update(name=self.my_domain.name)):
+            management.call_command('stop-abuse', self.my_domain)
+        self.assertGreater(models.RRset.objects.filter(domain__name=self.my_domains[1].name).count(), 1)
+
+    def test_only_disable_owner(self):
+        with self.assertPdnsRequests(self.requests_desec_rr_sets_update(name=self.my_domain.name)):
+            management.call_command('stop-abuse', self.my_domain)
+        self.my_domain.owner.refresh_from_db()
+        self.other_domain.owner.refresh_from_db()
+        self.assertEqual(self.my_domain.owner.is_active, False)
+        self.assertEqual(self.other_domain.owner.is_active, True)
+
+    def test_disable_owners(self):
+        with self.assertPdnsRequests(
+            self.requests_desec_rr_sets_update(name=self.my_domain.name),
+            self.requests_desec_rr_sets_update(name=self.other_domain.name),
+            expect_order=False,
+        ):
+            management.call_command('stop-abuse', self.my_domain, self.other_domain)
+        self.my_domain.owner.refresh_from_db()
+        self.other_domain.owner.refresh_from_db()
+        self.assertEqual(self.my_domain.owner.is_active, False)
+        self.assertEqual(self.other_domain.owner.is_active, False)

--- a/docker-compose.test-api.yml
+++ b/docker-compose.test-api.yml
@@ -1,4 +1,4 @@
-version: '2.2'
+version: '2.3'
 
 # mostly extending from main .yml
 services:

--- a/docker-compose.test-e2e2.yml
+++ b/docker-compose.test-e2e2.yml
@@ -1,4 +1,4 @@
-version: '2.2'
+version: '2.3'
 
 # mostly extending from main .yml
 services:


### PR DESCRIPTION
Introduces the `stop-abuse` command, which takes a list of domain names and:

1. removes all contents of the domains under these names except for `NS` records at the apox, and
2. disables all user accounts associated with any of the given domain names