### PR TITLE
feat(api): command for changing minimum TTL and domains limits

### DIFF
--- a/api/desecapi/management/commands/limit.py
+++ b/api/desecapi/management/commands/limit.py
@@ -1,0 +1,38 @@
+from django.core.management import BaseCommand, CommandError
+from django.db.models import Q
+
+from api import settings
+from desecapi.models import RRset, Domain, User
+from desecapi.pdns_change_tracker import PDNSChangeTracker
+
+
+class Command(BaseCommand):
+    help = 'Sets/updates limits for users and domains.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('kind',
+                            help='Identifies which limit should be updated. Possible values: domains, ttl')
+        parser.add_argument('id',
+                            help='Identifies the entity to be updated. Users are identified by email address; '
+                                 'domains by their name.')
+        parser.add_argument('new_limit', help='New value for the limit.')
+
+    def handle(self, *args, **options):
+        if options['kind'] == 'domains':
+            try:
+                user = User.objects.get(email=options['id'])
+            except User.DoesNotExist:
+                raise CommandError(f'User with email address "{options["id"]}" could not be found.')
+            user.limit_domains = options['new_limit']
+            user.save()
+            print(f'Updated {user.email}: set max number of domains to {user.limit_domains}.')
+        elif options['kind'] == 'ttl':
+            try:
+                domain = Domain.objects.get(name=options['id'])
+            except Domain.DoesNotExist:
+                raise CommandError(f'Domain with name "{options["id"]}" could not be found.')
+            domain.minimum_ttl = options['new_limit']
+            domain.save()
+            print(f'Updated {domain.name}: set minimum TTL to {domain.minimum_ttl}.')
+        else:
+            raise CommandError(f'Unknown limit "{options["kind"]}" specified.')

--- a/api/desecapi/tests/test_limit.py
+++ b/api/desecapi/tests/test_limit.py
@@ -1,0 +1,34 @@
+from django.core import management
+from django.db.models import Min
+
+from desecapi.models import Domain, RRset
+from desecapi.tests.base import DomainOwnerTestCase
+
+
+class LimitCommandTest(DomainOwnerTestCase):
+
+    def test_update_domains(self):
+        management.call_command('limit', 'domains', self.owner.email, '123')
+        self.owner.refresh_from_db()
+        self.assertEqual(self.owner.limit_domains, 123)
+        management.call_command('limit', 'domains', self.owner.email, 567)
+        self.owner.refresh_from_db()
+        self.assertEqual(self.owner.limit_domains, 567)
+        management.call_command('limit', 'domains', self.owner.email, '1')  # below the actual number of domains
+        self.owner.refresh_from_db()
+        self.assertEqual(self.owner.limit_domains, 1)
+        # did not delete domains below limit:
+        self.assertEqual(Domain.objects.filter(owner_id=self.owner.id).count(), 2)
+
+    def test_update_minimum_ttl(self):
+        management.call_command('limit', 'ttl', self.my_domain.name, '123')
+        self.my_domain.refresh_from_db()
+        self.assertEqual(self.my_domain.minimum_ttl, 123)
+        management.call_command('limit', 'ttl', self.my_domain.name, 567)
+        self.my_domain.refresh_from_db()
+        self.assertEqual(self.my_domain.minimum_ttl, 567)
+        management.call_command('limit', 'ttl', self.my_domain.name, '10000')  # above the currently used ttl
+        self.my_domain.refresh_from_db()
+        self.assertEqual(self.my_domain.minimum_ttl, 10000)
+        # did not change existing TTLs in violation of minimum TTL:
+        self.assertLess(RRset.objects.filter(domain_id=self.my_domain.id).aggregate(Min('ttl'))['ttl__min'], 10000)


### PR DESCRIPTION
Introduces a command to change limitations to user accounts and domains. Exact CLI is totally up for discussion, this is just a first idea. Open questions are how this could be extended to transfer domains between accounts, how to change other account details like email addresses, or trigger password resets, and so on.

Change number of domains limit for user@example.com to 50 domains:

    manage.py limits domains user@example.com 50

Change minimum TTL for example.com to 600:

    manage.py limits ttl example.com 600

Existing domains/records that are in violation of the newly introduced limit remain untouched.