### PR TITLE
change(ci): do not trigger ci build if just docs changed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,12 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
 
 env:
   DESECSTACK_DOMAIN: your.hostname.example.com


### PR DESCRIPTION
Source: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths

## Reason

My PR #621 was blocked by ci because build was temporary failing, but changes in folder `docs` have no influence to the actual build. 

## Impact

Saves ci time/res and faster ci results for PRs.

## Unchanged

Currently `readthedocs.org` runs a check for `docs` and gives a feedback for the PR.