### PR TITLE
fix(webapp): fix CSP header blocking inline font data

### DIFF
--- a/test/e2e2/spec/test_www.py
+++ b/test/e2e2/spec/test_www.py
@@ -89,7 +89,7 @@ def test_security_headers(api_anon):
     api_anon.headers = {}
     expected_headers = {
         'Strict-Transport-Security': 'max-age=31536000; includeSubdomains; preload',
-        'Content-Security-Policy': "default-src 'self'; frame-src 'none'; connect-src 'self'; font-src 'self'; "
+        'Content-Security-Policy': "default-src 'self'; frame-src 'none'; connect-src 'self'; font-src 'self' data:; "
                                    "img-src 'self' data:; media-src data:; script-src 'self' 'unsafe-eval'; "
                                    "style-src 'self' 'unsafe-inline'; base-uri 'self'; frame-ancestors 'none'; "
                                    "block-all-mixed-content; form-action 'none';",

--- a/www/conf/sites-available/90-desec.static.location
+++ b/www/conf/sites-available/90-desec.static.location
@@ -3,7 +3,7 @@
 #####
 location / {
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload" always;
-    add_header Content-Security-Policy "default-src 'self'; frame-src 'none'; connect-src 'self'; font-src 'self'; img-src 'self' data:; media-src data:; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; base-uri 'self'; frame-ancestors 'none'; block-all-mixed-content; form-action 'none';" always;
+    add_header Content-Security-Policy "default-src 'self'; frame-src 'none'; connect-src 'self'; font-src 'self' data:; img-src 'self' data:; media-src data:; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; base-uri 'self'; frame-ancestors 'none'; block-all-mixed-content; form-action 'none';" always;
     add_header X-Frame-Options "deny" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;


### PR DESCRIPTION
Webpack inserts small files into the code to minimize the number of requests. This is blocked by the past CSP rule in the browser.