### PR TITLE
fix(webapp): disable inline font

### DIFF
--- a/www/webapp/vue.config.js
+++ b/www/webapp/vue.config.js
@@ -4,4 +4,13 @@ module.exports = {
       allowedHosts: 'all',
     },
   },
+  chainWebpack: config => {
+    config.module
+      .rule('fonts')
+      .set('parser', {
+        dataUrlCondition: {
+          maxSize: 0 // Disable inline font to improve FCP (first contentful paint).
+        }
+      });
+  },
 };


### PR DESCRIPTION
Disable inline font to improve FCP (first contentful paint).
Disable to avoid violating CSP rules.

Obsoletes #629