### PR TITLE
feat(): larger common prefixes of Dockerfiles to speed up building

### DIFF
--- a/dbapi/Dockerfile
+++ b/dbapi/Dockerfile
@@ -2,13 +2,13 @@ FROM postgres:13-alpine
 
 RUN apk add --no-cache pwgen
 
-ADD docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
-
 USER postgres
 
 # mountable storage
 VOLUME /var/lib/postgresql/data
 
-COPY entrypoint-wrapper.sh /usr/local/bin/
 ENTRYPOINT ["entrypoint-wrapper.sh"]
 CMD ["postgres"]
+
+COPY entrypoint-wrapper.sh /usr/local/bin/
+ADD docker-entrypoint-initdb.d /docker-entrypoint-initdb.d

--- a/dbmaster/Dockerfile
+++ b/dbmaster/Dockerfile
@@ -2,13 +2,13 @@ FROM postgres:13-alpine
 
 RUN apk add --no-cache pwgen
 
-ADD docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
-
 USER postgres
 
 # mountable storage
 VOLUME /var/lib/postgresql/data
 
-COPY entrypoint-wrapper.sh /usr/local/bin/
 ENTRYPOINT ["entrypoint-wrapper.sh"]
 CMD ["postgres"]
+
+COPY entrypoint-wrapper.sh /usr/local/bin/
+ADD docker-entrypoint-initdb.d /docker-entrypoint-initdb.d

--- a/nslord/Dockerfile
+++ b/nslord/Dockerfile
@@ -1,33 +1,29 @@
 FROM ubuntu:jammy
 
-RUN apt-get update && apt-get install -y \
-		dnsutils \
-		net-tools \
-		dirmngr gnupg \
-		faketime \
-	--no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY ./entrypoint.sh /root/
+CMD ["/root/entrypoint.sh"]
 
-RUN echo 'deb [arch=amd64] http://repo.powerdns.com/ubuntu jammy-auth-48 main' \
-      >> /etc/apt/sources.list \
- && echo 'Package: pdns-*' \
-      > /etc/apt/preferences.d/pdns \
- && echo 'Pin: origin repo.powerdns.com' \
-      >> /etc/apt/preferences.d/pdns \
- && echo 'Pin-Priority: 600' \
-      >> /etc/apt/preferences.d/pdns
+RUN apt-get update && apt-get install -y \
+    dnsutils \
+    iptables \
+    net-tools \
+    dirmngr gnupg \
+    # credentials management via envsubst
+    && apt-get -y install gettext-base \
+    --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN set -ex \
-	&& apt-key adv --keyserver keyserver.ubuntu.com --recv 0x1B0C6205FD380FBB \
-	&& apt-get update \
-	&& apt-get install -y pdns-server pdns-backend-mysql \
-	# credentials management via envsubst
-	&& apt-get -y install gettext-base \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*
+    && echo 'deb [arch=amd64] http://repo.powerdns.com/ubuntu jammy-auth-48 main' \
+        >> /etc/apt/sources.list \
+    && echo 'Package: pdns-*' > /etc/apt/preferences.d/pdns \
+    && echo 'Pin: origin repo.powerdns.com' >> /etc/apt/preferences.d/pdns \
+    && echo 'Pin-Priority: 600' >> /etc/apt/preferences.d/pdns \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv 0x1B0C6205FD380FBB
 
-RUN rm -rf /etc/powerdns/
+RUN apt-get update \
+    && apt-get install -y pdns-server pdns-backend-mysql faketime \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /etc/powerdns/
+
 COPY conf/ /etc/powerdns/
-
-COPY ./entrypoint.sh /root/
-
-CMD ["/root/entrypoint.sh"]

--- a/nsmaster/Dockerfile
+++ b/nsmaster/Dockerfile
@@ -1,35 +1,29 @@
 FROM ubuntu:jammy
 
-RUN apt-get update && apt-get install -y \
-		dnsutils \
-		iptables \
-		net-tools \
-		dirmngr gnupg \
-	--no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY ./entrypoint.sh /root/
+CMD ["/root/entrypoint.sh"]
 
-RUN echo 'deb [arch=amd64] http://repo.powerdns.com/ubuntu jammy-auth-48 main' \
-      >> /etc/apt/sources.list \
- && echo 'Package: pdns-*' \
-      > /etc/apt/preferences.d/pdns \
- && echo 'Pin: origin repo.powerdns.com' \
-      >> /etc/apt/preferences.d/pdns \
- && echo 'Pin-Priority: 600' \
-      >> /etc/apt/preferences.d/pdns
+RUN apt-get update && apt-get install -y \
+    dnsutils \
+    iptables \
+    net-tools \
+    dirmngr gnupg \
+    # credentials management via envsubst
+    && apt-get -y install gettext-base \
+    --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN set -ex \
-	&& apt-key adv --keyserver keyserver.ubuntu.com --recv 0x1B0C6205FD380FBB \
-	&& apt-get update \
-	&& apt-get install -y pdns-server pdns-backend-pgsql postgresql-client-14 \
-	# credentials management via envsubst
-	&& apt-get -y install gettext-base \
-	# VPN route
-	&& apt-get -y install iproute2 \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/*
+    && echo 'deb [arch=amd64] http://repo.powerdns.com/ubuntu jammy-auth-48 main' \
+        >> /etc/apt/sources.list \
+    && echo 'Package: pdns-*' > /etc/apt/preferences.d/pdns \
+    && echo 'Pin: origin repo.powerdns.com' >> /etc/apt/preferences.d/pdns \
+    && echo 'Pin-Priority: 600' >> /etc/apt/preferences.d/pdns \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv 0x1B0C6205FD380FBB
 
-RUN rm -rf /etc/powerdns/
+RUN apt-get update \
+    && apt-get install -y pdns-server pdns-backend-pgsql postgresql-client-14 iproute2 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /etc/powerdns/
+
 COPY conf/ /etc/powerdns/
-
-COPY ./entrypoint.sh /root/
-
-CMD ["/root/entrypoint.sh"]


### PR DESCRIPTION
This PR unifies the procedures of some similar Dockerfiles that we have such that they have more common steps, which I hope can reduce the build time and total image size.

This results in some images having unnecessary installations, in particular:

- nslord: iptables iproute2 pdns-backend-pgsql postgresql-client-10
- nsmaster: faketime pdns-backend-mysql

The last 15 builds on GitHub took 478s on average (std: 53s). Let's see how long it takes in this PR. (Data: 6:37 9:07 8:23 7:03 7:26 7:19 7:24 7:08 7:22 7:18 9:11 8:56 8:32 9:32 7:53)

Alternatives to this PR are:

1. Wait (possibly) longer for builds/deployments
2. More docker image layers
  - removing apt package lists requires longer build time for repeated `apt update`
  - not removing apt package lists requires larger layer sizes

