### PR TITLE
www: Enable compression for static files

### DIFF
--- a/test/e2e2/spec/test_www.py
+++ b/test/e2e2/spec/test_www.py
@@ -101,3 +101,23 @@ def test_security_headers(api_anon):
     response = api_anon.get(https_url)
     for k, v in expected_headers.items():
         assert response.headers[k] == v
+
+
+def test_compression(api_anon):
+    # compression for supporting clients on static files
+    assert api_anon.get(
+        f'https://desec.{os.environ["DESECSTACK_DOMAIN"]}/',
+        headers={'Accept-Encoding': 'Accept-Encoding: gzip, deflate'},
+    ).headers['Content-Encoding'] == 'gzip'
+
+
+def test_no_compression(api_anon):
+    # no compression for non-supporting clients on static files
+    assert 'Content-Encoding' not in api_anon.get(
+        f'https://desec.{os.environ["DESECSTACK_DOMAIN"]}/',
+    )
+    # no compression for supporting clients on api
+    assert 'Content-Encoding' not in api_anon.get(
+        f'https://desec.{os.environ["DESECSTACK_DOMAIN"]}/api/v1/',
+        headers={'Accept-Encoding': 'Accept-Encoding: gzip, deflate'},
+    )

--- a/www/conf/sites-available/90-desec.static.content
+++ b/www/conf/sites-available/90-desec.static.content
@@ -2,3 +2,4 @@ root   /usr/share/nginx/html/;
 index  index.html;
 try_files $uri $uri/ /index.html =404;
 error_page 403 =503 /503.html;
+gzip on;


### PR DESCRIPTION
This PR

1. disables redirects from www.dedyn.$DESECSTACK_DOMAIN and dedyn.$DESECSTACK_DOMAIN to desec.$DESECSTACK_DOMAIN, and
2. enables compression for serving static files.

Rationale:

1. These redirects could associate deSEC with malicious content hosted on dedyn domains. Also, the redirects will become a problem should we ever have more than one local public suffix domain -- each one would require separate certificates and nginx config.
2. Speed up webapp loading @Rotzbua #631 I have not enabled compression for API responses out of an unsubstantiated fear that this may break clients.

Merge #408 first.
