### PR TITLE
fix(api): update credentials_changed when (unused) TOTP is created

### DIFF
--- a/api/desecapi/models/users.py
+++ b/api/desecapi/models/users.py
@@ -112,6 +112,11 @@ class User(ExportModelOperationsMixin("User"), AbstractBaseUser):
         logger.warning(f"User {pk} deleted")
         return ret
 
+    def save(self, *args, **kwargs):
+        if kwargs.pop("credentials_changed", False):
+            self.credentials_changed = timezone.now()
+        super().save(*args, **kwargs)
+
     def send_email(
         self, reason, context=None, recipient=None, subject=None, template=None
     ):

--- a/api/desecapi/tests/test_user_management.py
+++ b/api/desecapi/tests/test_user_management.py
@@ -651,6 +651,21 @@ class NoUserAccountTestCase(UserLifeCycleTestCase):
         self.assertStatus(response, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["password"][0], "This field may not be null.")
 
+    def test_no_login_with_wrong_password(self):
+        email, password = self._test_registration(password="right123")
+        response = self.client.login_user(email, "wrong123")
+        self.assertStatus(response, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["detail"], "Invalid username/password.")
+
+    def test_no_login_when_inactive(self):
+        email, password = self._test_registration(password=self.random_password())
+        user = User.objects.get(email=email)
+        user.is_active = False
+        user.save()
+        response = self.client.login_user(email, password)
+        self.assertStatus(response, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["detail"], "Invalid username/password.")
+
     def test_registration_spam_protection(self):
         email = self.random_username()
         self.assertRegistrationSuccessResponse(

--- a/docs/auth/account.rst
+++ b/docs/auth/account.rst
@@ -169,7 +169,7 @@ If email address and password match our records, the server will reply with
 As indicated in the response, login tokens expire 7 days after creation or
 when not used for 1 hour, whichever comes first (see :ref:`token object`).
 
-In case of credential mismatch, the server replies with ``401 Unauthorized``.
+In case of credential mismatch, the server returns ``403 Permission Denied``.
 
 **Note:** Every time you send a ``POST`` request to this endpoint, an
 additional token will be created. Existing tokens will *remain valid*.

--- a/docs/auth/account.rst
+++ b/docs/auth/account.rst
@@ -151,11 +151,23 @@ If email address and password match our records, the server will reply with
 ``200 OK`` and return the token secret in the ``token`` field of the response body::
 
     {
-        "created": "2018-09-06T09:07:43.762697Z",
-        "id": "8f9cbae2-c862-48a4-b3f0-2cb1a80df168",
-        "token": "f07Q0TRmEb-CRWPe4h64_iV2jbet",
-        "name": "login"
+        "allowed_subnets": [
+            "0.0.0.0/0",
+            "::/0"
+        ],
+        "created": "2022-09-06T16:23:24.585329Z",
+        "id": "f7ab039b-07b8-493d-ac61-4ddcf903d4de",
+        "is_valid": true,
+        "last_used": null,
+        "max_age": "7 00:00:00",
+        "max_unused_period": "01:00:00",
+        "name": "",
+        "perm_manage_tokens": true,
+        "token": "i-T3b1h_OI-H9ab8tRS98stGtURe"
     }
+
+As indicated in the response, login tokens expire 7 days after creation or
+when not used for 1 hour, whichever comes first (see :ref:`token object`).
 
 In case of credential mismatch, the server replies with ``401 Unauthorized``.
 

--- a/docs/dns/domains.rst
+++ b/docs/dns/domains.rst
@@ -261,9 +261,9 @@ Exporting a Domain as Zonefile
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To export domain data in zonefile format, send a ``GET`` request to the
-``zonefile`` endpoint of this domain, i.e. to ``/domains/{name}/zonefile``::
+``zonefile`` endpoint of this domain, i.e. to ``/domains/{name}/zonefile/``::
 
-    curl -X GET https://desec.io/api/v1/domains/{name}/zonefile \
+    curl -X GET https://desec.io/api/v1/domains/{name}/zonefile/ \
         --header "Authorization: Token {secret}"
 
 Note that this will return a plain-text zonefile format without JSON formatting

--- a/www/webapp/src/utils.js
+++ b/www/webapp/src/utils.js
@@ -48,9 +48,13 @@ function _digestError(error, app) {
         } else {
           return ['You are not logged in.'];
         }
-      } else if (error.response.status === 403) { // MFA
-        app.$router.push({ name: 'mfa', query: { redirect: app.$route.fullPath }});
-        return [];
+      } else if (error.response.status === 403) {
+          if (store.state.authenticated) { // MFA
+            app.$router.push({name: 'mfa', query: {redirect: app.$route.fullPath}});
+            return [];
+          } else { // unauthenticated 403, i.e. login failure
+            return [error.response.data.detail]
+          }
       } else if (error.response.status === 413) {
         return ['Too much data. Try to reduce the length of your inputs.'];
       } else if ('data' in error.response) {

--- a/www/webapp/src/views/Console/TOTPVerifyDialog.vue
+++ b/www/webapp/src/views/Console/TOTPVerifyDialog.vue
@@ -58,7 +58,7 @@
                     required
                     :disabled="working"
                     tabindex="2"
-                    @finish="focusSubmit"
+                    @finish="verify"
                 />
               </v-col>
             </v-row>
@@ -124,11 +124,6 @@ export default {
   methods: {
     close() {
       this.show = false;
-    },
-    focusSubmit() {
-      setTimeout(() => {
-        this.$refs.submit.$el.focus();
-      });
     },
     async verify() {
       if (!this.$refs.form.validate()) {

--- a/www/webapp/src/views/MFA.vue
+++ b/www/webapp/src/views/MFA.vue
@@ -52,7 +52,7 @@
                       required
                       :disabled="working"
                       tabindex="2"
-                      @finish="focusSubmit"
+                      @finish="verify"
                   />
                 </v-col>
               </v-row>
@@ -111,11 +111,6 @@ export default {
     error(ex) {
       this.errors.splice(0, this.errors.length);
       this.errors.push(...digestError(ex, this));
-    },
-    focusSubmit() {
-      setTimeout(() => {
-        this.$refs.submit.$el.focus();
-      });
     },
     async verify() {
       if (!this.$refs.form.validate()) {


### PR DESCRIPTION
Previously, credentials_changed was only updated when the factor was
first verified. As a result, when an activation link was clicked
twice, the state was unchanged, so the action would attempt to create
the factor again, causing a uniqueness error.

Our `exception_handler` (exception_handlers.py) correctly turned this
into a 409 response, but the ugly database message was exposed, and
an admin email was triggered.

With this commit, the auth action state is invalidated immediately
when the TOTP factor is created.