### PR TITLE
Multi-IP updates; base58 tokens

### DIFF
--- a/api/desecapi/models/tokens.py
+++ b/api/desecapi/models/tokens.py
@@ -18,6 +18,11 @@ from django_prometheus.models import ExportModelOperationsMixin
 from netfields import CidrAddressField, NetManager
 
 
+# No 0OIl characters, non-alphanumeric only (select by double-click no line-break)
+# https://github.com/bitcoin/bitcoin/blob/master/src/base58.h
+ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
 class Token(ExportModelOperationsMixin("Token"), rest_framework.authtoken.models.Token):
     @staticmethod
     def _allowed_subnets_default():
@@ -73,7 +78,8 @@ class Token(ExportModelOperationsMixin("Token"), rest_framework.authtoken.models
         return True
 
     def generate_key(self):
-        self.plain = secrets.token_urlsafe(21)
+        # Entropy: len(ALPHABET) == 58, log_2(58) * 28 = 164.02
+        self.plain = "".join(secrets.choice(ALPHABET) for _ in range(28))
         self.key = Token.make_hash(self.plain)
         return self.key
 

--- a/docs/auth/tokens.rst
+++ b/docs/auth/tokens.rst
@@ -396,14 +396,28 @@ Security Considerations
 This section is for purely informational. Token length and encoding may change
 in the future.
 
-Any token secret is generated from 168 bits of randomness at the server and stored in
-hashed format (PBKDF2-HMAC-SHA256). Guessing the secret correctly or reversing
-the hash is hence practically impossible.
+Any token secret is generated from 164 bits of randomness at the server and
+stored in hashed format (PBKDF2-HMAC-SHA256).
+Guessing the secret correctly or reversing the hash is considered practically
+impossible.
 
-The token's secret value is represented by 28 characters using a URL-safe variant of
-base64 encoding. It comprises only the characters ``A-Z``, ``a-z``, ``0-9``, ``-``,
-and ``_``. (Base64 padding is not needed as the string length is a multiple of 4.)
+The token's secret value is represented by 28 characters using a URL-safe
+base58 encoding.
+It is based on a case-sensitive alphanumeric alphabet excluding the characters
+``lIO0`` (hence comprising only the symbols ``a-k``, ``m-z``, ``A-H``,
+``J-N``, ``P-Z``, and ``1-9``).
+This encoding is optimized for maximum clarity and usability:
+Exclusion of certain letters minimizes visual ambiguity, while the restriction
+to alphanumeric symbols allows easy selection (double-click) and input, and
+helps avoid line breaks during display.
 
-Old versions of the API encoded 20-byte token secrets in 40 characters with hexadecimal
-representation. Such tokens are not issued anymore, but remain valid until
-invalidated by the user.
+Before December 2022, tokens encoded at 21-byte secret using 28 characters in
+a URL-safe variant of base64 encoding, comprising only of the characters
+``A-Z``, ``a-z``, ``0-9``, ``-``, and ``_``.
+(Base64 padding was not needed as the string length is a multiple of 4.)
+
+Before September 2018, tokens encoded a 20-byte secret using 40 hexadecimal
+characters.
+
+Legacy tokens are not issued anymore, but remain valid until invalidated by
+the user.

--- a/docs/dyndns/update-api.rst
+++ b/docs/dyndns/update-api.rst
@@ -105,16 +105,17 @@ To update more than one domain name, please see
 
 .. _determine-ip-addresses:
 
-Determine IP Addresses
-**********************
+Determine IP Address(es)
+************************
 The last ingredient we need for a successful update of your DNS records is your
 IPv4 and/or IPv6 addresses, for storage in the ``A`` and ``AAAA`` records,
 respectively.
 
 For IPv4, we check the query string parameters ``myip``, ``myipv4``, ``ip``
-(in this order) for an IPv4 address to record in the database.
-When the special string ``preserve`` is provided instead of an IP address, the
-address on record (if any) will be kept as is.
+(in this order) for IPv4 addresses to record in the database.
+Multiple IP addresses may be given as a comma-separated list.
+When the special string ``preserve`` is provided instead, the configuration
+on record (if any) will be kept as is.
 If none of the parameters is set, the connection's client IP address will be
 used if it is an IPv4 connection; otherwise the IPv4 address will be deleted
 from the DNS.
@@ -124,9 +125,12 @@ For IPv6, the procedure is similar.
 We check the ``myipv6``, ``ipv6``, ``myip``, ``ip`` query string parameters
 (in this order) and the IP that was used to connect to the API for IPv6
 addresses and use the first one found.
-The ``preserve`` rule applies as above.
+Both the multi-IP syntax and the ``preserve`` rule apply as above.
 If nothing is found or an empty value provided, the ``AAAA`` record will be
 deleted.
+
+When using the ``myip`` parameter, a mixed-type list of both IPv4 and IPv6
+addresses may be given.
 
 
 Update Response


### PR DESCRIPTION
Missing:
- [x] final implementation
- [x] tests
- [x] docs

`_find_ip()` currently raises a `ValueError` when contradicting parameters are given (like `&myip=1.2.3.4,,preserve`). Although this could be converted into a DRF exception, it would be nicer to make this part of some serializer validation error. The problem is that the serializer currently used is not aware of the `""` and `"preserve"` special values.

How do proceed? Should we move the whole query parameter handling to a new dynDNS serializer? (In that case, perhaps it's better to abandon this for now. I thought it's a very small change.) @nils-wisiol 