### PR TITLE
chore(webapp): remove unnecessary parentheses

### DIFF
--- a/www/webapp/src/views/CrudList.vue
+++ b/www/webapp/src/views/CrudList.vue
@@ -419,10 +419,10 @@ export default {
       create: () => ('Create a new object.'),
       createBottom: () => undefined,
       createSuccess: () => undefined,
-      createWarning: () => (false),
+      createWarning: () => false,
       destroy: () => ('Delete an object permanently. This operation can likely not be undone.'),
-      destroyInfo: () => (false),
-      destroyWarning: () => (false),
+      destroyInfo: () => false,
+      destroyWarning: () => false,
     },
     columns: {},
     // resource


### PR DESCRIPTION
Not really important code style fix, but fixed annoying lint warning while working on the other PRs 😉 