### PR TITLE
feat(webapp): add robots.txt for SEO

### DIFF
--- a/www/html/429.html
+++ b/www/html/429.html
@@ -1,7 +1,13 @@
-<html>
-<head><title>429 Too Many Requests</title></head>
-<body bgcolor="white">
-<center><h1>429 Too Many Requests</h1></center>
-<hr><center>nginx</center>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="robots" content="noindex">
+<title>429 Too Many Requests</title>
+</head>
+<body style="background-color: white">
+<div style="text-align: center;"><h1>429 Too Many Requests</h1></div>
+<hr>
+<div style="text-align: center;">nginx</div>
 </body>
 </html>

--- a/www/html/503.html
+++ b/www/html/503.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
+<meta name="robots" content="noindex">
 <title>deSEC &ndash; Maintenance</title>
 <style>
     body {
@@ -12,8 +14,8 @@
 </head>
 <body>
 <h1>Ongoing Maintenance</h1>
-<p>Our page is currently undergoing maintenance and should be back in a bit.<br/>
+<p>Our page is currently undergoing maintenance and should be back in a bit.<br>
 Please try again later.</p>
-<p><em>Stay secure,<br/>deSEC Team</em></p>
+<p><em>Stay secure,<br>deSEC Team</em></p>
 </body>
 </html>

--- a/www/html/check.html
+++ b/www/html/check.html
@@ -44,15 +44,14 @@ h1, h2 {
 <h1>dynDNS Check</h1>
 <h2 id="domain">Domain: </h2>
 <div id="results">
-    <div class="waiting" id="ipv4_records"><b>IPv4:</b> <span>checking ...<span></div>
-    <div class="waiting" id="ipv6_records"><b>IPv6:</b> <span>checking ...<span></div>
+    <div class="waiting" id="ipv4_records"><b>IPv4:</b> <span>checking ...</span></div>
+    <div class="waiting" id="ipv6_records"><b>IPv6:</b> <span>checking ...</span></div>
 </div>
-<p id="footer">dedyn.io is a dynDNS service provided by <a href="https://desec.io/">deSEC</a>.</pre>
-</body>
+<p id="footer">dedyn.io is a dynDNS service provided by <a href="https://desec.io/">deSEC</a>.</p>
 
 <script>
 function getRecords(token, domain, type, callback) {
-    var req = new XMLHttpRequest();
+    const req = new XMLHttpRequest();
     req.addEventListener("load", callback);
     req.open("GET", "https://desec.io/api/v1/domains/" + domain + "/rrsets/?subname=&type=" + type);
     req.setRequestHeader("Authorization", "Token " + token);
@@ -60,7 +59,8 @@ function getRecords(token, domain, type, callback) {
 }
 
 function setRecordsElement(elementId, status, data) {
-    className = "error";
+    let className = "error";
+    let textContent = "(check failed)";
     if (status == 401) {
         textContent = "(unauthorized)";
     } else if (status == 404) {
@@ -73,16 +73,14 @@ function setRecordsElement(elementId, status, data) {
             className = "warning";
             textContent = "(none)";
         }
-    } else {
-        textContent = "(check failed)";
     }
-    element = document.getElementById(elementId)
+    const element = document.getElementById(elementId);
     element.className = className;
     element.lastElementChild.textContent = textContent;
 }
 
-domain = location.search.substr(1)
-token = location.hash.substr(1);
+domain = location.search.substring(1)
+token = location.hash.substring(1);
 
 if (domain.length) {
     document.getElementById("domain").textContent = "Domain: " + domain;
@@ -103,4 +101,5 @@ if (!token.length || !domain.length) {
 }
 </script>
 
+</body>
 </html>

--- a/www/webapp/public/robots.txt
+++ b/www/webapp/public/robots.txt
@@ -1,0 +1,2 @@
+user-agent: *
+disallow: /api/


### PR DESCRIPTION
Avoid indexation and robot rage of `/api/`.

## Background

Some robots may find a link `domain.or/api/xyz` and then try to index the complete api causing a pseudo DOS attack. Good robots will check the robots.txt and stop doing this. Evil robots will do this anyway.

## Reference

* https://web.dev/robots-txt/