### PR TITLE
fix(webapp): warning vue/no-reserved-component-names

### DIFF
--- a/www/webapp/src/components/Field/GenericCode.vue
+++ b/www/webapp/src/components/Field/GenericCode.vue
@@ -3,8 +3,9 @@
 </template>
 
 <script>
+// TODO still required? seems not used.
 export default {
-  name: 'Code',
+  name: 'GenericCode',
   props: {
     value: {
       type: String,

--- a/www/webapp/src/views/CrudList.vue
+++ b/www/webapp/src/views/CrudList.vue
@@ -344,7 +344,7 @@ import { HTTP, withWorking, digestError } from '@/utils';
 import RRSetType from '@/components/Field/RRSetType';
 import TimeAgo from '@/components/Field/TimeAgo';
 import Checkbox from '@/components/Field/Checkbox';
-import Code from '@/components/Field/Code';
+import GenericCode from '@/components/Field/GenericCode';
 import GenericText from '@/components/Field/GenericText';
 import GenericTextarea from '@/components/Field/GenericTextarea';
 import Record from '@/components/Field/Record';
@@ -372,7 +372,7 @@ export default {
     TimeAgo,
     Switchbox,
     Checkbox,
-    Code,
+    GenericCode,
     GenericText,
     GenericTextarea,
     Record,


### PR DESCRIPTION
* fix warning Name "Code" is reserved in HTML vue/no-reserved-component-names
* renamed component

## Reference

Mentioned in #662