### PR TITLE
fix(webapp): warning vue/no-v-text-v-html-on-component

### DIFF
--- a/www/webapp/src/views/About.vue
+++ b/www/webapp/src/views/About.vue
@@ -36,7 +36,7 @@
         <v-row class="pb-8">
           <v-col class="col-12 col-sm-6 d-flex" v-for="p in purposes" :key="p.title">
             <v-card>
-              <v-card-title v-text="p.title"></v-card-title>
+              <v-card-title>{{p.title}}</v-card-title>
               <v-card-text>{{p.text}}</v-card-text>
             </v-card>
           </v-col>

--- a/www/webapp/src/views/PrivacyPolicy.vue
+++ b/www/webapp/src/views/PrivacyPolicy.vue
@@ -10,7 +10,7 @@
         <v-row class="pb-8">
           <v-col class="col-12 col-sm-6 d-flex" v-for="p in privacy_policy" :key="p.title">
             <v-card>
-              <v-card-title v-text="p.title"></v-card-title>
+              <v-card-title>{{p.title}}</v-card-title>
               <v-card-text>{{p.text}}</v-card-text>
             </v-card>
           </v-col>

--- a/www/webapp/src/views/Terms.vue
+++ b/www/webapp/src/views/Terms.vue
@@ -32,7 +32,7 @@
         <v-col class="col-12 col-sm-6 d-flex" v-for="(t, idx) in terms_of_use" :key="t.title">
           <v-card>
             <v-card-title>§{{idx+1}} {{t.title}}</v-card-title>
-            <v-card-text v-html="t.text" />
+            <v-card-text><span v-html="t.text"></span></v-card-text>
           </v-card>
         </v-col>
       </v-row>


### PR DESCRIPTION
* fix warning Using v-html on component may break component's content vue/no-v-text-v-html-on-component
* add pure html tag to insert html
* fix warning Using v-text on component may break component's content vue/no-v-text-v-html-on-component
* set the "normal" way

## Reference

Mentioned in #662