### PR TITLE
fix(api): allow underscores in CNAME targets

### DIFF
--- a/api/desecapi/tests/test_rrsets.py
+++ b/api/desecapi/tests/test_rrsets.py
@@ -840,7 +840,7 @@ class AuthenticatedRRSetTestCase(AuthenticatedRRSetBaseTestCase):
                 "61655 13 4 C838A5C66FCBF83B8B6B50C3CEEC3524777FE4AF8A9FE0172ECAD242 48B0CA1A216DD0D538F20C130DD3059538204B04",
                 "6454 8 5 24396E17E36D031F71C354B06A979A67A01F503E",
             ],
-            "CNAME": ["example.com."],
+            "CNAME": ["example.com.", "*._under-score.-foo_bar.example.net.", "."],
             "CSYNC": ["0 0", "66 1 A", "66 2 AAAA", "66 3 A NS AAAA", "66 15 NSEC"],
             "DHCID": ["aaaaaaaaaaaa", "aa aaa  aaaa a a a"],
             "DLV": [

--- a/test/e2e2/spec/test_api_rr.py
+++ b/test/e2e2/spec/test_api_rr.py
@@ -169,7 +169,7 @@ VALID_RECORDS_NON_CANONICAL = {
         '6454 8 2 5C BA665A006F6487625C6218522F09BD3673C25FA10F25CB18459AA1 0DF1F520',
     ],
     'CERT': ['6 0 0 sadfdQ==', '06 00 00 sadfee==', 'IPGP 00 00 sadfee=='],
-    'CNAME': ['EXAMPLE.TEST.'],
+    'CNAME': ['EXAMPLE.TEST.', '*._under-score.-foo_bar.example.net.'],
     'CSYNC': ['066 03  NS  AAAA A'],
     'DHCID': ['aa aaa  aaaa a a a', 'xxxx'],
     'DLV': [


### PR DESCRIPTION
The previous check was based on the wrong pdns code location. Consultation on pdns IRC revealed the right one.

Fixes regression from 0605f3879012ce6dc4c06f5d7711875348c9e468