### PR TITLE
Migrate from `@mdi/font` to `@mdi/js`

### DIFF
--- a/www/webapp/package.json
+++ b/www/webapp/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@fontsource/roboto": "^4.5.8",
     "@mdi/font": "^6.9.96",
+    "@mdi/js": "~7.2.96",
     "axios": "^0.27.2",
     "core-js": "^3.27.1",
     "javascript-time-ago": "^2.5.9",

--- a/www/webapp/src/App.vue
+++ b/www/webapp/src/App.vue
@@ -70,7 +70,7 @@
                       v-on="on"
               >
                 more
-                <v-icon right>mdi-menu-down</v-icon>
+                <v-icon right>{{mdiMenuDown}}</v-icon>
               </v-btn>
             </template>
 
@@ -153,7 +153,7 @@
         <div>
           <p>
             Please <router-link :to="{name: 'donate'}">donate</router-link>!
-            <v-icon color="red" class="text--darken-2" dense>mdi-heart</v-icon>
+            <v-icon color="red" class="text--darken-2" dense>{{mdiHeart}}</v-icon>
           </p>
           <p>
             European Bank Account:<br>
@@ -182,6 +182,17 @@
 import router from '@/router';
 import {logout} from '@/utils';
 import {useUserStore} from "@/store/user";
+import {
+    mdiBookOpenPageVariant,
+    mdiForumOutline,
+    mdiGiftOutline,
+    mdiHeart,
+    mdiHome,
+    mdiLockReset,
+    mdiMenuDown,
+    mdiRoadVariant,
+    mdiUmbrella
+} from "@mdi/js";
 
 export default {
   name: 'App',
@@ -189,42 +200,44 @@ export default {
     user: useUserStore(),
     drawer: false,
     email: process.env.VUE_APP_EMAIL,
+    mdiHeart,
+    mdiMenuDown,
     menu: {
       'home': {
         'name': 'home',
-        'icon': 'mdi-home',
+        'icon': mdiHome,
         'text': 'Home',
       },
       'docs': {
         'name': 'docs',
-        'icon': 'mdi-book-open-page-variant',
+        'icon': mdiBookOpenPageVariant,
         'text': 'Docs',
       },
       'roadmap': {
         'name': 'roadmap',
-        'icon': 'mdi-road-variant',
+        'icon': mdiRoadVariant,
         'text': 'Roadmap',
       },
       'talk': {
         'name': 'talk',
-        'icon': 'mdi-forum-outline',
+        'icon': mdiForumOutline,
         'text': 'Talk',
       },
       'donate': {
         'name': 'donate',
-        'icon': 'mdi-gift-outline',
+        'icon': mdiGiftOutline,
         'text': 'Donate',
-        'post_icon': 'mdi-heart',
+        'post_icon': mdiHeart,
         'post_icon_color': 'red',
       },
       'about': {
         'name': 'about',
-        'icon': 'mdi-umbrella',
+        'icon': mdiUmbrella,
         'text': 'About',
       },
       'reset-password': {
         'name': 'reset-password',
-        'icon': 'mdi-lock-reset',
+        'icon': mdiLockReset,
         'text': 'Reset Account Password',
       },
     },

--- a/www/webapp/src/components/DonateDirectDebitForm.vue
+++ b/www/webapp/src/components/DonateDirectDebitForm.vue
@@ -35,7 +35,7 @@
       <v-text-field
               v-model="name"
               label="Full Name of the Account Holder"
-              prepend-icon="mdi-account"
+              :prepend-icon="mdiAccount"
               outline
               required
               :disabled="working"
@@ -46,7 +46,7 @@
       <v-text-field
               v-model="iban"
               label="IBAN"
-              prepend-icon="mdi-bank"
+              :prepend-icon="mdiBank"
               outline
               required
               :disabled="working"
@@ -58,7 +58,7 @@
       <v-text-field
               v-model="amount"
               label="Amount in Euros"
-              prepend-icon="mdi-cash-100"
+              :prepend-icon="mdiCash100"
               outline
               required
               :disabled="working"
@@ -69,7 +69,7 @@
       <v-text-field
               v-model="message"
               label="Message (optional)"
-              prepend-icon="mdi-message-text-outline"
+              :prepend-icon="mdiMessageTextOutline"
               outline
               :disabled="working"
               validate-on-blur
@@ -78,7 +78,7 @@
       <v-text-field
               v-model="email"
               label="Email Address (optional)"
-              prepend-icon="mdi-email"
+              :prepend-icon="mdiEmail"
               outline
               :disabled="working"
               :rules="email_rules"
@@ -103,6 +103,7 @@
   import {email_pattern} from '@/validation';
   import {digestError} from '@/utils';
   import ErrorAlert from '@/components/ErrorAlert';
+  import {mdiAccount, mdiBank, mdiCash100, mdiEmail, mdiMessageTextOutline} from "@mdi/js";
 
   const HTTP = axios.create({
     baseURL: '/api/v1/',
@@ -120,6 +121,13 @@
       working: false,
       done: false,
       errors: [],
+
+      /* icons */
+      mdiAccount,
+      mdiBank,
+      mdiCash100,
+      mdiMessageTextOutline,
+      mdiEmail,
 
       /* from env */
       creditorid: process.env.VUE_APP_DESECSTACK_API_SEPA_CREDITOR_ID,

--- a/www/webapp/src/components/Field/RecordList.vue
+++ b/www/webapp/src/components/Field/RecordList.vue
@@ -7,7 +7,7 @@
             :content="item"
             :error-messages="errorMessages[index] ? errorMessages[index].content : []"
             :hide-label="index > 0"
-            :append-icon="value.length > 1 ? 'mdi-close' : ''"
+            :append-icon="value.length > 1 ? mdiClose : ''"
             :disabled="disabled"
             :readonly="readonly"
             :required="required"
@@ -24,7 +24,7 @@
             small
             text
             v-if="!readonly && !disabled"
-    ><v-icon>mdi-plus</v-icon> add another value</v-btn>
+    ><v-icon>{{mdiPlus}}</v-icon> add another value</v-btn>
     <!--div><code style="white-space: normal">{{ value }}</code></div-->
   </div>
 </template>
@@ -50,6 +50,7 @@ import RecordSVCB from './Record/SVCB.vue';
 import RecordTLSA from './Record/TLSA.vue';
 import RecordTXT from './Record/TXT.vue';
 import RecordSubnet from './Record/Subnet.vue';
+import {mdiClose, mdiPlus} from "@mdi/js";
 
 export default {
   name: 'RecordList',
@@ -104,6 +105,8 @@ export default {
   data: function () {
     const self = this;
     return {
+      mdiClose,
+      mdiPlus,
       types: [
         'A',
         'AAAA',

--- a/www/webapp/src/plugins/vuetify.js
+++ b/www/webapp/src/plugins/vuetify.js
@@ -7,6 +7,9 @@ Vue.use(Vuetify);
 
 
 export default new Vuetify({
+  icons: {
+    iconfont: 'mdiSvg', // 'mdi' || 'mdiSvg' || 'md' || 'fa' || 'fa4' || 'faSvg'
+  },
   theme: {
     themes: {
       light: {

--- a/www/webapp/src/views/Console/DomainSetupDialog.vue
+++ b/www/webapp/src/views/Console/DomainSetupDialog.vue
@@ -13,7 +13,7 @@
         </div>
         <v-spacer/>
         <v-icon @click.stop="close">
-          mdi-close
+          {{ mdiClose }}
         </v-icon>
       </v-card-title>
       <v-divider/>
@@ -35,6 +35,7 @@
 
 <script>
 import DomainSetup from "@/views/DomainSetup";
+import {mdiClose} from "@mdi/js";
 
 export default {
   name: 'DomainSetupDialog',
@@ -50,6 +51,7 @@ export default {
     },
   },
   data: () => ({
+    mdiClose,
     value: {
       type: Boolean,
       default: true,

--- a/www/webapp/src/views/Console/TOTPVerifyDialog.vue
+++ b/www/webapp/src/views/Console/TOTPVerifyDialog.vue
@@ -14,7 +14,7 @@
           </div>
           <v-spacer/>
           <v-icon @click.stop="close">
-            mdi-close
+            {{mdiClose}}
           </v-icon>
         </v-card-title>
         <v-divider/>
@@ -29,14 +29,14 @@
 
         <v-card-text v-if="!!successDetail" class="text-center">
           <p class="mt-2">
-            <v-icon>mdi-check</v-icon>
+            <v-icon>{{mdiCheck}}</v-icon>
             Great! Continue to <router-link :to="{name: 'login'}">log in</router-link>.
           </p>
         </v-card-text>
 
         <v-card-text v-if="!!data && !successDetail" class="text-center">
           <p class="mt-2">
-            <v-icon>mdi-numeric-1-circle</v-icon>
+            <v-icon>{{mdiNumeric1Circle}}</v-icon>
             Please scan the following QR code with an authenticator app (e.g. Google Authenticator).<br />
             <strong>This code is only displayed once.</strong>
           </p>
@@ -44,7 +44,7 @@
             <qrcode-vue :value="data.uri" size="300" level="H"/>
           </div>
           <p class="mt-6">
-            <v-icon>mdi-numeric-2-circle</v-icon>
+            <v-icon>{{mdiNumeric2Circle}}</v-icon>
             Enter the code displayed in the authenticator app to confirm and activate the token:
           </p>
 
@@ -93,6 +93,7 @@
 import {digestError, HTTP, withWorking} from '@/utils'
 import ErrorAlert from "../../components/ErrorAlert";
 import QrcodeVue from '../../modules/qrcode.vue/dist/qrcode.vue.esm'
+import {mdiCheck, mdiClose, mdiNumeric1Circle, mdiNumeric2Circle} from "@mdi/js";
 
 export default {
   name: 'TOTPVerifyDialog',
@@ -120,6 +121,10 @@ export default {
     errors: [],
     working: false,
     show: true,
+    mdiCheck,
+    mdiClose,
+    mdiNumeric1Circle,
+    mdiNumeric2Circle,
   }),
   methods: {
     close() {

--- a/www/webapp/src/views/CrudList.vue
+++ b/www/webapp/src/views/CrudList.vue
@@ -40,7 +40,7 @@
                 <v-text-field
                         v-model="search"
                         v-if="$vuetify.breakpoint.smAndUp"
-                        append-icon="mdi-magnify"
+                        :append-icon="mdiMagnify"
                         label="Search"
                         single-line
                         hide-details
@@ -62,12 +62,12 @@
                         depressed
                         :disabled="user.working"
                 >
-                  <v-icon>mdi-plus</v-icon>
+                  <v-icon>{{mdiPlus}}</v-icon>
                 </v-btn>
                 <template #extension v-if="$vuetify.breakpoint.xsOnly">
                   <v-text-field
                           v-model="search"
-                          append-icon="mdi-magnify"
+                          :append-icon="mdiMagnify"
                           label="Search"
                           single-line
                           hide-details
@@ -87,7 +87,7 @@
                         <span class="headline">{{ headlines.create }}</span>
                         <v-spacer />
                         <v-icon @click.stop="close">
-                          mdi-close
+                          {{ mdiClose }}
                         </v-icon>
                       </v-card-title>
                       <v-divider />
@@ -352,6 +352,7 @@ import GenericSwitchbox from '@/components/Field/GenericSwitchbox.vue';
 import TTL from '@/components/Field/TTL';
 import ErrorAlert from '@/components/ErrorAlert'
 import {useUserStore} from "@/store/user";
+import {mdiClose, mdiContentSaveEdit, mdiDelete, mdiMagnify, mdiPlus} from "@mdi/js";
 
 const filter = function (obj, predicate) {
   const result = {};
@@ -449,6 +450,11 @@ export default {
       }
     },
     handleRowClick: () => {},
+    mdiClose,
+    mdiDelete,
+    mdiContentSaveEdit,
+    mdiMagnify,
+    mdiPlus,
   }},
   computed: {
     actions: () => {},
@@ -458,13 +464,13 @@ export default {
         'save': {
           go: d => this.save(d),
           if: this.updatable,
-          icon: 'mdi-content-save-edit',
+          icon: mdiContentSaveEdit,
           tooltip: 'Save',
         },
         'delete': {
           go: d => this.destroyAsk(d),
           if: this.destroyable,
-          icon: 'mdi-delete',
+          icon: mdiDelete,
           tooltip: 'Delete',
         },
       }

--- a/www/webapp/src/views/CrudListDomain.vue
+++ b/www/webapp/src/views/CrudListDomain.vue
@@ -2,6 +2,7 @@
 import { HTTP, withWorking } from '@/utils';
 import CrudList from './CrudList';
 import DomainSetupDialog from '@/views/Console/DomainSetupDialog';
+import {mdiDownload, mdiInformation} from "@mdi/js";
 
 export default {
   name: 'CrudListDomain',
@@ -120,12 +121,12 @@ export default {
       return {
         'info': {
           go: d => this.showDomainInfo(d),
-          icon: 'mdi-information',
+          icon: mdiInformation,
           tooltip: 'Setup instructions',
         },
         'export': {
           go: d => this.exportDomain(d),
-          icon: 'mdi-download',
+          icon: mdiDownload,
           if: this.showAdvanced,
           tooltip: 'Export (zonefile format)',
         },

--- a/www/webapp/src/views/DonatePage.vue
+++ b/www/webapp/src/views/DonatePage.vue
@@ -18,7 +18,7 @@
               <v-expansion-panel>
                 <v-expansion-panel-header class="subtitle-1">
                   <v-layout>
-                    <v-icon class="mr-2">mdi-bank-transfer-in</v-icon> Direct Debit – Let us Take your Money (Europe)
+                    <v-icon class="mr-2">{{mdiBankTransferIn}}</v-icon> Direct Debit – Let us Take your Money (Europe)
                   </v-layout>
                 </v-expansion-panel-header>
                 <v-expansion-panel-content class="pt-4">
@@ -32,7 +32,7 @@
               <v-expansion-panel>
                 <v-expansion-panel-header class="subtitle-1">
                   <v-layout>
-                    <v-icon class="mr-2">mdi-bank-transfer-out</v-icon> Bank Transfer – Send us Money (Europe)
+                    <v-icon class="mr-2">{{mdiBankTransferOut}}</v-icon> Bank Transfer – Send us Money (Europe)
                   </v-layout>
                 </v-expansion-panel-header>
                 <v-expansion-panel-content class="pt-4">
@@ -63,7 +63,7 @@
               <v-expansion-panel>
                 <v-expansion-panel-header class="subtitle-1">
                   <v-layout>
-                    <v-icon class="mr-2">mdi-credit-card-outline</v-icon> Credit Card
+                    <v-icon class="mr-2">{{mdiCreditCardOutline}}</v-icon> Credit Card
                   </v-layout>
                 </v-expansion-panel-header>
                 <v-expansion-panel-content class="pt-4">
@@ -81,7 +81,7 @@
               <v-expansion-panel>
                 <v-expansion-panel-header class="subtitle-1">
                   <v-layout>
-                    <v-icon class="mr-2">mdi-github</v-icon> GitHub Sponsors
+                    <v-icon class="mr-2">{{mdiGithub}}</v-icon> GitHub Sponsors
                   </v-layout>
                 </v-expansion-panel-header>
                 <v-expansion-panel-content class="pt-4">
@@ -94,7 +94,7 @@
               <v-expansion-panel>
                 <v-expansion-panel-header class="subtitle-1">
                   <v-layout>
-                    <v-icon class="mr-2">mdi-gift-outline</v-icon> PayPal
+                    <v-icon class="mr-2">{{mdiGiftOutline}}</v-icon> PayPal
                   </v-layout>
                 </v-expansion-panel-header>
                 <v-expansion-panel-content class="pt-4">
@@ -112,7 +112,7 @@
               <v-expansion-panel>
                 <v-expansion-panel-header class="subtitle-1">
                   <v-layout>
-                    <v-icon class="mr-2">mdi-heart-multiple-outline</v-icon> Double-up with Your Employer
+                    <v-icon class="mr-2">{{mdiHeartMultipleOutline}}</v-icon> Double-up with Your Employer
                   </v-layout>
                 </v-expansion-panel-header>
                 <v-expansion-panel-content class="pt-4">
@@ -180,6 +180,7 @@
 <script>
   import DonateDirectDebitForm from '@/components/DonateDirectDebitForm.vue';
   import QrcodeVue from "../modules/qrcode.vue";
+  import {mdiBankTransferIn, mdiBankTransferOut, mdiCreditCardOutline, mdiGiftOutline, mdiGithub, mdiHeartMultipleOutline} from "@mdi/js";
 
   export default {
     name: 'DonatePage',
@@ -196,7 +197,13 @@
             "DE91830654080004158059\n" +
             "\n\n\n" +
             "Donation Spende deSEC e.V.\n"
-        )
+        ),
+        mdiBankTransferIn,
+        mdiBankTransferOut,
+        mdiCreditCardOutline,
+        mdiGithub,
+        mdiGiftOutline,
+        mdiHeartMultipleOutline
       }
     },
   }

--- a/www/webapp/src/views/HomePage.vue
+++ b/www/webapp/src/views/HomePage.vue
@@ -36,7 +36,7 @@
                     solo
                     flat
                     v-model="email"
-                    prepend-inner-icon="mdi-email"
+                    :prepend-inner-icon="mdiEmail"
                     type="email"
                     placeholder="Account Email Address"
                     :rules="email_rules"
@@ -188,6 +188,17 @@
 <script>
 import {email_pattern} from '@/validation';
 import {useUserStore} from "@/store/user";
+import {
+    mdiCertificate,
+    mdiCloudCheck,
+    mdiDatabaseArrowUp,
+    mdiDns, mdiEmail, mdiFileCertificate, mdiFlower, mdiGift, mdiHeartBroken,
+    mdiIpNetworkOutline, mdiLan,
+    mdiLockOutline,
+    mdiMonitorCellphoneStar,
+    mdiRobot, mdiRunFast,
+    mdiTwoFactorAuthentication
+} from "@mdi/js";
 
 export default {
   name: 'HomePage',
@@ -209,6 +220,7 @@ export default {
     }
   },
   data: () => ({
+    mdiEmail,
     contact_email: process.env.VUE_APP_EMAIL,
     contact_subject: 'Adopting of a Frontend Server',
     contact_body: 'Dear deSEC,\n\nI would like to adopt a frontend server in your networks!',
@@ -314,7 +326,7 @@ export default {
     features: [
       {
         href: '#',
-        icon: 'mdi-lock-outline',
+        icon: mdiLockOutline,
         title: 'DNSSEC',
         text: 'DNS information hosted at deSEC is <b>signed with DNSSEC, always</b>. We use state-of-the-art '
                + 'elliptic-curve cryptography. Besides following operational best practice, we adopt '
@@ -323,7 +335,7 @@ export default {
       },
       {
         href: '#',
-        icon: 'mdi-cloud-check',
+        icon: mdiCloudCheck,
         title: 'Cloud Integration',
         text: 'Thanks to <a href="https://talk.desec.io/t/tools-implementing-desec/11" target="_blank">cloud '
                 + 'integrations and language bindings</a>, deSEC works out of the box in automated environments. '
@@ -331,7 +343,7 @@ export default {
       },
       {
         href: '#',
-        icon: 'mdi-dns',
+        icon: mdiDns,
         title: 'Modern Record Types',
         text: 'We support a <a href="https://desec.readthedocs.io/en/latest/dns/rrsets.html#supported-types" target="_blank">broad '
                 + 'array of record types</a>, including novel types such as <code>HTTPS</code>/<code>SVCB</code> (for '
@@ -340,7 +352,7 @@ export default {
       },
       {
         href: '#',
-        icon: 'mdi-monitor-cellphone-star',
+        icon: mdiMonitorCellphoneStar,
         title: 'Web Interface',
         text: 'We think we have the <b>coolest GUI on the market</b>. Thanks to <b>real-time record validation</b> and '
                + 'parsing, it is <b>very intuitive and fast</b> to use (even on mobile devices). Get started by '
@@ -348,7 +360,7 @@ export default {
       },
       {
         href: '#',
-        icon: 'mdi-robot',
+        icon: mdiRobot,
         title: 'REST API',
         text: 'Exert full control over your DNS via our <b>modern API</b> and benefit from advanced features such as '
                + ' bulk operations. It is <a href="https://desec.readthedocs.io/en/latest/dns/domains.html" target="_blank">well-documented</a> '
@@ -356,14 +368,14 @@ export default {
       },
       {
         href: '#',
-        icon: 'mdi-two-factor-authentication',
+        icon: mdiTwoFactorAuthentication,
         title: 'Multi-Factor Auth (2FA)',
         text: 'Accidentally shared your password with someone? Enable MFA to <b>keep your account safe</b>. We '
               + 'currently support <b>TOTP tokens</b> (Authenticator app), with WebAuthn in the making.',
       },
       {
         href: '#',
-        icon: 'mdi-database-arrow-up',
+        icon: mdiDatabaseArrowUp,
         title: 'Scalability',
         text: 'Are you a web hoster? Start using deSEC, <b>even with thousands of domains</b>. Our global network '
                 + 'ensures <b>high availability and performance everywhere</b>. <a href="mailto:support@desec.io">Talk '
@@ -371,21 +383,21 @@ export default {
       },
       {
         href: '#',
-        icon: 'mdi-ip-network-outline',
+        icon: mdiIpNetworkOutline,
         title: 'IPv6',
         text: 'deSEC is <b>fully IPv6-aware</b>: administration can be done using v6, AAAA-records '
                 + 'containing IPv6 addresses can be set up, our name servers are reachable via IPv6.',
       },
       {
         href: '#',
-        icon: 'mdi-run-fast',
+        icon: mdiRunFast,
         title: 'Fast Updates',
         text: 'Updates to your DNS information will be <b>published world-wide within a few seconds</b>. '
                 + 'Minimum required TTLs are low.',
       },
       {
         href: '#',
-        icon: 'mdi-certificate',
+        icon: mdiCertificate,
         title: 'DANE / TLSA',
         text: 'Secure your web service with <code>TLSA</code> records, <b>hardening it against fraudulently issued SSL '
                 + 'certificates</b>. You can also use other DANE techniques, such as <code>OPENPGPKEY</code> key '
@@ -393,7 +405,7 @@ export default {
       },
       {
         href: '#',
-        icon: 'mdi-file-certificate',
+        icon: mdiFileCertificate,
         title: "Let's Encrypt Integration",
         text: 'We provide <b><a href="https://pypi.org/project/certbot-dns-desec/">easy integration</a> with Let\'s '
                + 'Encrypt</b> and their certbot tool. '
@@ -402,20 +414,20 @@ export default {
       },
       {
         href: '#',
-        icon: 'mdi-lan',
+        icon: mdiLan,
         title: 'Low-latency Anycast',
         text: 'We run <b>global networks of high-performance frontend DNS servers</b>. Your query is routed to the '
               + '<b>closest server</b> via Anycast, so clients receive answers as fast as possible.',
       },
       {
         href: '#',
-        icon: 'mdi-flower',
+        icon: mdiFlower,
         title: 'Open Source',
         text: 'deSEC runs <b>100% on free and open-source</b> software. Start hacking away!',
       },
       {
         href: '#',
-        icon: 'mdi-gift',
+        icon: mdiGift,
         title: 'Non-profit',
         text: 'deSEC is organized as a <b>non-profit organization based in Berlin</b>. We make sure that privacy '
               + 'is not compromised by business interest.',
@@ -426,7 +438,7 @@ export default {
         id: 'news-20201017001',
         start: new Date(Date.UTC(2020, 10 - 1, 17)),  // first day of showing
         end: new Date(Date.UTC(2020, 10 - 1, 20)),  // first day of not showing
-        icon: 'mdi-heart-broken',
+        icon: mdiHeartBroken,
         teaser: 'deSEC API and web services have been unavailable on 17 Oct 2020 starting at 4:26 am UTC and resumed ' +
             'normal operations at 10:13 am UTC. DNS operations continued throughout.',
         button: 'deSEC Status Details',
@@ -436,7 +448,7 @@ export default {
         id: 'news-20221010001',
         start: new Date(Date.UTC(2022, 10 - 1, 10)),  // first day of showing
         end: new Date(Date.UTC(2022, 10 - 1, 12)),  // first day of not showing
-        icon: 'mdi-heart-broken',
+        icon: mdiHeartBroken,
         teaser: "From 10 Oct 2022 11:32 am UTC until 10 Oct 2022 16:33 UTC, the deSEC web interface was unavailable " +
             "when accessed via direct links, e.g. though emails sent by deSEC. The issue has been fixed; links that " +
             "have not expired in the meantime are now working when opened. Direct login to the web interface and " +

--- a/www/webapp/src/views/MFA.vue
+++ b/www/webapp/src/views/MFA.vue
@@ -20,7 +20,7 @@
         <v-card-text class="text-center">
           <div>
             <p class="mt-2">
-              <v-icon>mdi-numeric-1-circle</v-icon>
+              <v-icon>{{ mdiNumeric1Circle }}</v-icon>
               Please select a TOTP token:
             </p>
             <v-container class="pa-0">
@@ -39,7 +39,7 @@
             </v-container>
 
             <p class="mt-6">
-              <v-icon>mdi-numeric-2-circle</v-icon>
+              <v-icon>{{ mdiNumeric2Circle }}</v-icon>
               Enter the code displayed in the authenticator app to continue:
             </p>
             <v-container class="pa-0">
@@ -81,6 +81,7 @@
 <script>
 import {digestError, HTTP, withWorking} from '@/utils'
 import ErrorAlert from "../components/ErrorAlert";
+import {mdiNumeric1Circle, mdiNumeric2Circle} from "@mdi/js";
 
 export default {
   name: 'MFA',
@@ -94,6 +95,8 @@ export default {
     id: null,
     working: false,
     show: true,
+    mdiNumeric1Circle,
+    mdiNumeric2Circle,
   }),
   async created() {
     const self = this;


### PR DESCRIPTION
Use tree shakeable version instead of big webfont.

Login, signup seems to need some refactoring. Migration later.

## Reference

Partial migration of #710