### PR TITLE
fix(webapp): migrate deprecated `substr()`

### DIFF
--- a/www/webapp/src/components/Field/RecordItem.vue
+++ b/www/webapp/src/components/Field/RecordItem.vue
@@ -228,7 +228,7 @@ export default {
 
       event.preventDefault();
       const pos = this.getPosition();
-      this.update(this.value.substr(0, pos - 1) + this.value.substr(pos), pos - 1);
+      this.update(this.value.slice(0, pos - 1) + this.value.slice(pos), pos - 1);
     },
     deleteHandler(index, event) {
       if (!this.positionBeforeDelimiter(index)) {
@@ -237,7 +237,7 @@ export default {
 
       event.preventDefault();
       const pos = this.getPosition();
-      this.update(this.value.substr(0, pos) + this.value.substr(pos + 1), pos);
+      this.update(this.value.slice(0, pos) + this.value.slice(pos + 1), pos);
     },
     leftHandler(index, event) {
       if (!this.positionAfterDelimiter(index)) {

--- a/www/webapp/src/views/DynSetup.vue
+++ b/www/webapp/src/views/DynSetup.vue
@@ -198,7 +198,7 @@
       if ('domain' in this.$route.params && this.$route.params.domain !== undefined) {
         this.domain = this.$route.params.domain;
       }
-      this.token = this.$route.hash.substr(1);
+      this.token = this.$route.hash.slice(1);
       this.check();
     },
     computed: {


### PR DESCRIPTION
## Problem

`substr()` is deprecated.

## Solution

Replace by `substring` or `slice`.

Used `slice` because it is used in the project.

## Reference

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr