### PR TITLE
fix(webapp): disable complete form not every input field

### DIFF
--- a/www/webapp/src/components/DonateDirectDebitForm.vue
+++ b/www/webapp/src/components/DonateDirectDebitForm.vue
@@ -19,7 +19,11 @@
       <p>Again, thank you so much.</p>
       <v-btn depressed outlined block :to="{name: 'home'}">Done</v-btn>
     </v-alert>
-    <v-form v-if="!done" @submit.prevent="donate" ref="form">
+    <v-form
+        v-if="!done"
+        @submit.prevent="donate"
+        :disabled="working"
+        ref="form">
       <error-alert :errors="errors"></error-alert>
 
       <v-radio-group
@@ -38,7 +42,6 @@
               :prepend-icon="mdiAccount"
               outlined
               required
-              :disabled="working"
               :rules="name_rules"
               :error-messages="name_errors"
       />
@@ -49,7 +52,6 @@
               :prepend-icon="mdiBank"
               outlined
               required
-              :disabled="working"
               :rules="iban_rules"
               :error-messages="iban_errors"
               validate-on-blur
@@ -61,7 +63,6 @@
               :prepend-icon="mdiCash100"
               outlined
               required
-              :disabled="working"
               :rules="amount_rules"
               :error-messages="amount_errors"
       />
@@ -71,7 +72,6 @@
               label="Message (optional)"
               :prepend-icon="mdiMessageTextOutline"
               outlined
-              :disabled="working"
               validate-on-blur
       />
 
@@ -80,7 +80,6 @@
               label="Email Address (optional)"
               :prepend-icon="mdiEmail"
               outlined
-              :disabled="working"
               :rules="email_rules"
               :error-messages="email_errors"
               validate-on-blur
@@ -91,7 +90,6 @@
               block
               color="primary"
               type="submit"
-              :disabled="working"
               :loading="working"
       >Donate Now</v-btn>
     </v-form>

--- a/www/webapp/src/views/ChangeEmail.vue
+++ b/www/webapp/src/views/ChangeEmail.vue
@@ -12,7 +12,11 @@
                     sm="8"
                     md="6"
             >
-                <v-form @submit.prevent="changeEmail" ref="form">
+                <v-form
+                    @submit.prevent="changeEmail"
+                    :disabled="working"
+                    ref="form"
+                >
                     <v-card class="elevation-12 pb-4">
                         <v-toolbar
                                 color="primary"
@@ -47,7 +51,6 @@
                                     outlined
                                     label="Password"
                                     required
-                                    :disabled="working"
                                     :rules="[rules.required]"
                                     :type="show ? 'text' : 'password'"
                                     :error-messages="password_errors"
@@ -62,7 +65,6 @@
                                     prepend-icon="mdi-email"
                                     outlined
                                     required
-                                    :disabled="working"
                                     :rules="[rules.required, rules.email]"
                                     :error-messages="email_errors"
                                     @change="email_errors=[]"
@@ -75,7 +77,6 @@
                                     depressed
                                     color="primary"
                                     type="submit"
-                                    :disabled="working"
                                     :loading="working"
                                     tabindex="3"
                             >Change Email Address

--- a/www/webapp/src/views/DeleteAccount.vue
+++ b/www/webapp/src/views/DeleteAccount.vue
@@ -12,7 +12,11 @@
                     sm="8"
                     md="6"
             >
-                <v-form @submit.prevent="deleteAccount" ref="form">
+                <v-form
+                    @submit.prevent="deleteAccount"
+                    :disabled="working"
+                    ref="form"
+                >
                     <v-card class="elevation-12 pb-4">
                         <v-toolbar
                                 color="primary"
@@ -45,7 +49,6 @@
                                     outlined
                                     label="Password"
                                     required
-                                    :disabled="working"
                                     :rules="[rules.required]"
                                     :type="show ? 'text' : 'password'"
                                     :error-messages="password_errors"
@@ -60,7 +63,6 @@
                                     depressed
                                     color="primary"
                                     type="submit"
-                                    :disabled="working"
                                     :loading="working"
                                     tabindex="2"
                             >Delete Account

--- a/www/webapp/src/views/LoginPage.vue
+++ b/www/webapp/src/views/LoginPage.vue
@@ -15,6 +15,7 @@
         <v-form
           v-model="valid"
           @submit.prevent="login"
+          :disabled="working"
         >
           <v-card class="elevation-12 pb-4">
             <v-toolbar
@@ -31,7 +32,6 @@
                 label="Email"
                 outlined
                 required
-                :disabled="working"
                 :rules="email_rules"
                 :error-messages="email_errors"
                 tabindex="1"
@@ -44,7 +44,6 @@
                 :type="hide_password ? 'password' : 'text'"
                 outlined
                 required
-                :disabled="working"
                 :rules="password_rules"
                 tabindex="2"
                 @click:append="() => (hide_password = !hide_password)"
@@ -63,7 +62,7 @@
                 type="submit"
                 color="primary"
                 depressed
-                :disabled="!valid || working"
+                :disabled="!valid"
                 :loading="working"
                 tabindex="4"
               >

--- a/www/webapp/src/views/ResetPassword.vue
+++ b/www/webapp/src/views/ResetPassword.vue
@@ -12,7 +12,11 @@
                     sm="8"
                     md="6"
             >
-                <v-form @submit.prevent="resetPassword" ref="form">
+                <v-form
+                    @submit.prevent="resetPassword"
+                    :disabled="working"
+                    ref="form"
+                >
                     <v-card class="elevation-12 pb-4">
                         <v-toolbar
                                 color="primary"
@@ -41,7 +45,6 @@
                                     prepend-icon="mdi-email"
                                     outlined
                                     required
-                                    :disabled="working"
                                     :rules="email_rules"
                                     :error-messages="email_errors"
                                     @change="email_errors=[]"
@@ -59,7 +62,6 @@
                                             prepend-icon="mdi-account-check"
                                             outlined
                                             required
-                                            :disabled="working"
                                             :rules="captcha_rules"
                                             :error-messages="captcha_errors"
                                             @change="captcha_errors=[]"
@@ -103,7 +105,6 @@
                                     depressed
                                     color="primary"
                                     type="submit"
-                                    :disabled="working"
                                     :loading="working"
                                     tabindex="3"
                             >Reset Password

--- a/www/webapp/src/views/SignUp.vue
+++ b/www/webapp/src/views/SignUp.vue
@@ -13,7 +13,11 @@
               md="8"
               lg="6"
       >
-        <v-form @submit.prevent="signup" ref="form">
+        <v-form
+            @submit.prevent="signup"
+            :disabled="working"
+            ref="form"
+        >
           <v-card class="elevation-12 pb-4">
             <v-toolbar
                     color="primary"
@@ -31,7 +35,6 @@
                       prepend-icon="mdi-email"
                       outlined
                       required
-                      :disabled="working"
                       :rules="email_rules"
                       :error-messages="email_errors"
                       @change="email_errors=[]"
@@ -58,7 +61,7 @@
                       prepend-icon="mdi-blank"
                       outlined
                       required
-                      :disabled="working || domainType === 'none' || domainType === undefined"
+                      :disabled="domainType === 'none' || domainType === undefined"
                       :rules="domainType === 'dynDNS' ? dyn_domain_rules : (domainType === 'custom' ? domain_rules : [])"
                       :error-messages="domain_errors"
                       :suffix="domainType === 'dynDNS' ? ('.' + LOCAL_PUBLIC_SUFFIXES[0]) : ''"
@@ -82,7 +85,6 @@
                         prepend-icon="mdi-account-check"
                         outlined
                         required
-                        :disabled="working"
                         :rules="captcha_rules"
                         :error-messages="captcha_errors"
                         @change="captcha_errors=[]"
@@ -126,7 +128,6 @@
                       v-model="outreach_preference"
                       hide-details
                       type="checkbox"
-                      :disabled="working"
                       tabindex="5"
                 >
                   <template #label>
@@ -142,7 +143,6 @@
                       v-model="terms"
                       hide-details="auto"
                       type="checkbox"
-                      :disabled="working"
                       :rules="terms_rules"
                       tabindex="6"
                 >
@@ -161,7 +161,6 @@
                       class="px-4"
                       color="primary"
                       type="submit"
-                      :disabled="working"
                       :loading="working"
                       tabindex="7"
               >Sign up</v-btn>

--- a/www/webapp/src/views/SignUp.vue
+++ b/www/webapp/src/views/SignUp.vue
@@ -70,7 +70,7 @@
                       ref="domainField"
                       tabindex="3"
                       :hint="domainType === 'dynDNS'
-                        ? 'After sign-up, we will send you instructions on how to configure your dynDNS client (such as you router).'
+                        ? 'After sign-up, we will send you instructions on how to configure your dynDNS client (such as your router).'
                         : 'Your first domain (you can add more later). – To use with dynDNS, please see the docs.'
                       "
                       persistent-hint


### PR DESCRIPTION
## Change

Disable form instead of every input field.

## Reason

Vuetify did not support the disable-forms-feature from the beginning. Today it supports to disable the form instead of every single form input.

## Fixes

Signup: domain selection is not disabled.

## Reference

https://github.com/vuetifyjs/vuetify/releases/tag/v2.3.0
