### PR TITLE
feat(webapp): use `eslint` as standalone

### DIFF
--- a/www/webapp/.eslintrc.js
+++ b/www/webapp/.eslintrc.js
@@ -1,8 +1,12 @@
+/* eslint-env node */
+
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
   root: true,
   env: {
-    node: true
+    browser: true,
+    node: true, // Can be removed after migration to vite.
+    es2022: true,
   },
   extends: [
     'plugin:vue/essential',
@@ -24,17 +28,4 @@ module.exports = {
     'vue/no-deprecated-html-element-is': 'warn', // Preparation for vue3
   },
   ignorePatterns: ['**/src/modules/**/*'],
-  parserOptions: {
-    parser: '@babel/eslint-parser'
-  },
-  overrides: [
-    {
-      files: [
-        '**/__tests__/*.{j,t}s?(x)'
-      ],
-      env: {
-        mocha: true
-      }
-    }
-  ]
 }

--- a/www/webapp/package.json
+++ b/www/webapp/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint --no-fix",
-    "lint:fix": "vue-cli-service lint --fix"
+    "lint": "eslint --ignore-path .gitignore --no-fix  src/",
+    "lint:fix": "eslint --ignore-path .gitignore --fix  src/"
   },
   "dependencies": {
     "@fontsource/roboto": "^5.0.3",
@@ -22,9 +22,7 @@
     "vuetify": "^2.6.13"
   },
   "devDependencies": {
-    "@babel/eslint-parser": "^7.19.1",
     "@vue/cli-plugin-babel": "^5.0.8",
-    "@vue/cli-plugin-eslint": "^5.0.8",
     "@vue/cli-plugin-router": "^5.0.8",
     "@vue/cli-service": "^5.0.8",
     "eslint": "^8.31.0",


### PR DESCRIPTION
Remove dependency on vue-cli to enable migration to vite.