### PR TITLE
fix(nginx): migrate deprecated config

### DIFF
--- a/www/conf/sites-available/00-default.conf.var
+++ b/www/conf/sites-available/00-default.conf.var
@@ -9,8 +9,9 @@ server {
 	return 444; # see https://httpstatuses.com/444
 }
 server {
-	listen 443 ssl http2 default_server;
-	listen [::]:443 ipv6only=on ssl http2 default_server;
+	listen 443 ssl default_server;
+	listen [::]:443 ipv6only=on ssl default_server;
+	http2 on;
 	server_name _;
 
 	ssl_certificate ${CERT_PATH}desec.${DESECSTACK_DOMAIN}.cer;

--- a/www/conf/sites-available/05-dedyn.conf.var
+++ b/www/conf/sites-available/05-dedyn.conf.var
@@ -14,8 +14,9 @@ server {
 	}
 }
 server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
+	listen 443 ssl;
+	listen [::]:443 ssl;
+	http2 on;
 	server_name dedyn.$DESECSTACK_DOMAIN;
 
 	ssl_certificate ${CERT_PATH}dedyn.${DESECSTACK_DOMAIN}.cer;
@@ -35,8 +36,9 @@ server {
         }
 }
 server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
+	listen 443 ssl;
+	listen [::]:443 ssl;
+	http2 on;
 	server_name www.dedyn.$DESECSTACK_DOMAIN;
 
 	ssl_certificate ${CERT_PATH}www.dedyn.${DESECSTACK_DOMAIN}.cer;

--- a/www/conf/sites-available/10-dedyn-checkip.conf.var
+++ b/www/conf/sites-available/10-dedyn-checkip.conf.var
@@ -24,7 +24,8 @@ server {
 	}
 }
 server {
-	listen 443 ssl http2;
+	listen 443 ssl;
+	http2 on;
 	server_name checkipv4.dedyn.$DESECSTACK_DOMAIN;
 	
 	ssl_certificate ${CERT_PATH}checkipv4.dedyn.${DESECSTACK_DOMAIN}.cer;
@@ -54,7 +55,8 @@ server {
 	}
 }
 server {
-	listen [::]:443 ssl http2;
+	listen [::]:443 ssl;
+	http2 on;
 	server_name checkipv6.dedyn.$DESECSTACK_DOMAIN;
 	
 	ssl_certificate ${CERT_PATH}checkipv6.dedyn.${DESECSTACK_DOMAIN}.cer;
@@ -85,8 +87,9 @@ server {
 	}
 }
 server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
+	listen 443 ssl;
+	listen [::]:443 ssl;
+	http2 on;
 	server_name checkip.dedyn.$DESECSTACK_DOMAIN;
 	
 	ssl_certificate ${CERT_PATH}checkip.dedyn.${DESECSTACK_DOMAIN}.cer;

--- a/www/conf/sites-available/15-dedyn-update.conf.var
+++ b/www/conf/sites-available/15-dedyn-update.conf.var
@@ -27,8 +27,9 @@ server {
 # Handle update requests with SSL
 ######
 server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
+	listen 443 ssl;
+	listen [::]:443 ssl;
+	http2 on;
 	server_name update.dedyn.$DESECSTACK_DOMAIN;
 	
 	ssl_certificate ${CERT_PATH}update.dedyn.${DESECSTACK_DOMAIN}.cer;
@@ -55,7 +56,8 @@ server {
 	}
 }
 server {
-	listen [::]:443 ssl http2;
+	listen [::]:443 ssl;
+	http2 on;
 	server_name update6.dedyn.$DESECSTACK_DOMAIN;
 	
 	ssl_certificate ${CERT_PATH}update6.dedyn.${DESECSTACK_DOMAIN}.cer;

--- a/www/conf/sites-available/85-redirects.conf.var
+++ b/www/conf/sites-available/85-redirects.conf.var
@@ -19,8 +19,9 @@ server {
 # Strip www. from HTTPS requests on www.desec.*
 ######
 server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
+	listen 443 ssl;
+	listen [::]:443 ssl;
+	http2 on;
 	server_name www.desec.$DESECSTACK_DOMAIN;
 
 	ssl_certificate ${CERT_PATH}www.desec.${DESECSTACK_DOMAIN}.cer;
@@ -38,8 +39,9 @@ server {
 # For the "get" subdomain, we redirect to the main page for now
 ######
 server {
-        listen 443 ssl http2;
-        listen [::]:443 ssl http2;
+        listen 443 ssl;
+        listen [::]:443 ssl;
+        http2 on;
         server_name get.desec.$DESECSTACK_DOMAIN;
 
         ssl_certificate ${CERT_PATH}get.desec.${DESECSTACK_DOMAIN}.cer;

--- a/www/conf/sites-available/90-desec.conf.var
+++ b/www/conf/sites-available/90-desec.conf.var
@@ -2,8 +2,9 @@
 # The website server
 ######
 server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
+	listen 443 ssl;
+	listen [::]:443 ssl;
+	http2 on;
 	server_name desec.$DESECSTACK_DOMAIN;
 
 	ssl_certificate ${CERT_PATH}desec.${DESECSTACK_DOMAIN}.cer;


### PR DESCRIPTION
## Change

Migrates deprecated http2 nginx config.

## Reference

* fixes #787
* Changes with nginx 1.25.1 (13 Jun 2023)
  Feature: the "http2" directive, which enables HTTP/2 on a per-server basis; the "http2" parameter of the "listen" directive is now deprecated.