### PR TITLE
fix(webapp): add missing hashes to CSP

### DIFF
--- a/test/e2e2/spec/test_www.py
+++ b/test/e2e2/spec/test_www.py
@@ -87,10 +87,13 @@ def test_unknown_hosts(api_anon, protocol, hostname):
 
 def test_security_headers(api_anon):
     api_anon.headers = {}
+    # CSP hashes are for legacy browser support.
+    # Source: https://github.com/vitejs/vite/tree/v4/packages/plugin-legacy#content-security-policy
     expected_headers = {
         'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
         'Content-Security-Policy': "default-src 'self'; frame-src 'none'; connect-src 'self'; font-src 'self' data:; "
-                                   "img-src 'self' data:; media-src data:; script-src 'self' 'unsafe-eval'; "
+                                   "img-src 'self' data:; media-src data:; "
+                                   "script-src 'self' 'unsafe-eval' 'sha256-MS6/3FCg4WjP9gwgaBGwLpRCY6fZBgwmhVCdrPrNf3E=' 'sha256-tQjf8gvb2ROOMapIxFvFAYBeUJ0v1HCbOcSmDNXGtDo=' 'sha256-4y/gEB2/KIwZFTfNqwXJq4olzvmQ0S214m9jwKgNXoc=' 'sha256-+5XkZFazzJo8n0iOP4ti/cLCMUudTf//Mzkb7xNPXIc='; "
                                    "style-src 'self' 'unsafe-inline'; base-uri 'self'; frame-ancestors 'none'; "
                                    "block-all-mixed-content; form-action 'none';",
         'X-Frame-Options': 'deny',

--- a/www/conf/sites-available/90-desec.static.location
+++ b/www/conf/sites-available/90-desec.static.location
@@ -11,7 +11,9 @@ location / {
     location /index.html {  # Also includes / via internal redirect, see https://nginx.org/en/docs/http/ngx_http_index_module.html#index
         expires epoch;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-        add_header Content-Security-Policy "default-src 'self'; frame-src 'none'; connect-src 'self'; font-src 'self' data:; img-src 'self' data:; media-src data:; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; base-uri 'self'; frame-ancestors 'none'; block-all-mixed-content; form-action 'none';" always;
+        # CSP hashes are for legacy browser support.
+        # Source: https://github.com/vitejs/vite/tree/v4/packages/plugin-legacy#content-security-policy
+        add_header Content-Security-Policy "default-src 'self'; frame-src 'none'; connect-src 'self'; font-src 'self' data:; img-src 'self' data:; media-src data:; script-src 'self' 'unsafe-eval' 'sha256-MS6/3FCg4WjP9gwgaBGwLpRCY6fZBgwmhVCdrPrNf3E=' 'sha256-tQjf8gvb2ROOMapIxFvFAYBeUJ0v1HCbOcSmDNXGtDo=' 'sha256-4y/gEB2/KIwZFTfNqwXJq4olzvmQ0S214m9jwKgNXoc=' 'sha256-+5XkZFazzJo8n0iOP4ti/cLCMUudTf//Mzkb7xNPXIc='; style-src 'self' 'unsafe-inline'; base-uri 'self'; frame-ancestors 'none'; block-all-mixed-content; form-action 'none';" always;
         add_header X-Frame-Options "deny" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;


### PR DESCRIPTION
Add inline script hashes for `@vitejs/plugin-legacy`:

Add the corresponding hashes to your script-src list:

    sha256-MS6/3FCg4WjP9gwgaBGwLpRCY6fZBgwmhVCdrPrNf3E=
    sha256-tQjf8gvb2ROOMapIxFvFAYBeUJ0v1HCbOcSmDNXGtDo=
    sha256-4y/gEB2/KIwZFTfNqwXJq4olzvmQ0S214m9jwKgNXoc=
    sha256-+5XkZFazzJo8n0iOP4ti/cLCMUudTf//Mzkb7xNPXIc=

Source:
https://github.com/vitejs/vite/tree/main/packages/plugin-legacy#content-security-policy

## Reference

fixes #788