### PR TITLE
fix(openvpn): update config for v2.5

### DIFF
--- a/openvpn-server/conf/server.conf
+++ b/openvpn-server/conf/server.conf
@@ -10,7 +10,9 @@ key /etc/openvpn/secrets/server.key  # This file should be kept secret
 
 tls-version-min 1.3 or-highest
 tls-cipher TLS-ECDHE-RSA-WITH-AES-256-GCM-SHA384
-ncp-ciphers AES-256-GCM
+data-ciphers AES-256-GCM
+# Fallback for OpenVPN before version 2.5, use "-" to disable support.
+data-ciphers-fallback AES-256-GCM
 auth SHA256
 dh none
 ecdh-curve secp384r1


### PR DESCRIPTION
## Change

Fixes warning:
* Note: Treating option '--ncp-ciphers' as  '--data-ciphers' (renamed in OpenVPN 2.5).
* --cipher is not set. Previous OpenVPN version defaulted to BF-CBC as fallback when cipher negotiation failed in this case. If you need this fallback please add '--data-ciphers-fallback BF-CBC' to your configuration and/or add BF-CBC to --data-ciphers.

## Reference

* #795
* Source: https://community.openvpn.net/openvpn/wiki/CipherNegotiation