### PR TITLE
docs: Add daemon timeout to ddclient config

### DIFF
--- a/docs/dyndns/configure.rst
+++ b/docs/dyndns/configure.rst
@@ -123,6 +123,8 @@ file similar to this one, with the three placeholders replaced by your domain
 name and your token secret::
 
   protocol=dyndns2
+  # Run in daemon mode: auto-update DNS every 10min. (Alternatively, use cron.)
+  #daemon=600
   # "use=cmd" and the curl command is one way of doing this; other ways exist
   use=cmd, cmd='curl https://checkipv4.dedyn.io/'
   ssl=yes


### PR DESCRIPTION
Daemon is needed in the most cases, as by default the user isn't expected to enable it by themselves or via a separate cron. This can may prevent from unexpected outages of the host.