### PR TITLE
fix(webapp): dependabot ignore `eslint`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
       day: "monday"
       time: "05:00"
     ignore:
+      - dependency-name: "eslint"
       - dependency-name: "sass"
     groups:
       npm-webapp:


### PR DESCRIPTION
eslint v9 has breaking changes and plugins are not yet fully compatible.

So let dependabot ignore `eslint`.