### PR TITLE
feat(www): optional hybrid PQC key exchange for TLS connections

### DIFF
--- a/www/Dockerfile
+++ b/www/Dockerfile
@@ -1,3 +1,20 @@
+FROM alpine AS oqs-provider
+
+RUN apk add --no-cache cmake git g++ make ninja openssl openssl-dev
+
+ARG LIBOQS_VERSION="0.12.0"
+ARG OQSPROVIDER_VERSION="0.8.0"
+
+RUN if [ -z ${LIBOQS_VERSION} ]; then exit 1; fi;
+RUN if [ -z ${OQSPROVIDER_VERSION} ]; then exit 2; fi;
+
+RUN git clone --depth 1 --branch ${LIBOQS_VERSION} https://github.com/open-quantum-safe/liboqs.git
+RUN git clone --depth 1 --branch ${OQSPROVIDER_VERSION} https://github.com/open-quantum-safe/oqs-provider.git
+
+ARG liboqs_DIR=/.local
+RUN cd liboqs && cmake -GNinja -DCMAKE_INSTALL_PREFIX=$liboqs_DIR -S . -B _build && cd _build && ninja && ninja install
+RUN cd oqs-provider && cmake -S . -B _build && cmake --build _build && cmake --install _build
+
 FROM node:lts AS webapp
 RUN \
   apt-get update \
@@ -28,6 +45,19 @@ FROM nginx:mainline-alpine
 
 # Add dependencies for our scripts
 RUN apk add --no-cache bash openssl inotify-tools
+
+# configure openssl to use OQS provider
+COPY --from=oqs-provider /oqs-provider/_build/lib/oqsprovider.so /usr/local/lib/
+RUN cat <<EOF  >> /etc/ssl/openssl.cnf
+[provider_sect]
+default = default_sect
+oqsprovider = oqsprovider_sect
+[default_sect]
+activate = 1
+[oqsprovider_sect]
+activate = 1
+module = /usr/local/lib/oqsprovider.so
+EOF
 
 # nginx configuration and entrypoint
 COPY conf /etc/nginx

--- a/www/conf/conf.d/ssl.conf
+++ b/www/conf/conf.d/ssl.conf
@@ -1,6 +1,11 @@
-# According to https://ssl-config.mozilla.org/#server=nginx&version=1.16.1&config=intermediate&openssl=1.1.1c&guideline=5.4 and added PQC hybrids support
+# generated 2025-02-04, Mozilla Guideline v5.4, nginx 1.27.3, OpenSSL 3.3.2, intermediate config
+# https://ssl-config.mozilla.org/#server=nginx&version=1.27.3&config=intermediate&openssl=3.3.2&guideline=5.4 and added PQC hybrids support
 ssl_protocols TLSv1.2 TLSv1.3;
 ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
 ssl_prefer_server_ciphers off;
 ssl_dhparam /etc/nginx/dhparam.pem;
-ssl_ecdh_curve X25519MLKEM768:x25519_kyber768:p384_kyber768:x25519:secp384r1:x448:secp256r1:secp521r1;
+ssl_ecdh_curve X25519MLKEM768:x25519_kyber768:p384_kyber768:x25519:secp384r1:x448:secp256r1:secp521r1:prime256v1;
+
+# see also ssl_session_ticket_key alternative to stateful session cache
+ssl_session_timeout 1d;
+ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions

--- a/www/conf/conf.d/ssl.conf
+++ b/www/conf/conf.d/ssl.conf
@@ -1,5 +1,6 @@
-# According to https://ssl-config.mozilla.org/#server=nginx&version=1.16.1&config=intermediate&openssl=1.1.1c&guideline=5.4
+# According to https://ssl-config.mozilla.org/#server=nginx&version=1.16.1&config=intermediate&openssl=1.1.1c&guideline=5.4 and added PQC hybrids support
 ssl_protocols TLSv1.2 TLSv1.3;
 ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
 ssl_prefer_server_ciphers off;
 ssl_dhparam /etc/nginx/dhparam.pem;
+ssl_ecdh_curve X25519MLKEM768:x25519_kyber768:p384_kyber768:x25519:secp384r1:x448:secp256r1:secp521r1;


### PR DESCRIPTION
Enables key agreement for TLS connections of www using hybrid PQC schemes (ECDHE + ML-KEM). Does not remove support for pure classical schemes (ECDHE only). Does not remove support for non-elliptic-curve DHE-RSA key agreement.

Hybrid PQC schemes using ML-KEM are supported from Chrome 131 onward; Firefox from 132 onward.