### PR TITLE
Webapp: warn if subname ends with domain name

### DIFF
--- a/api/desecapi/models/records.py
+++ b/api/desecapi/models/records.py
@@ -57,6 +57,10 @@ RR_SET_TYPES_MANAGEABLE = (
 
 
 def replace_ip_subnet(queryset, subnet):
+    """
+    Fetches A or AAAA record contents from an RRset queryset (depending on the subnet's
+    address family) and returns them with their subnet bits replaced accordingly.
+    """
     subnet = ip_network(subnet, strict=False)
     try:
         records = queryset.get(

--- a/www/webapp/src/components/Field/GenericText.vue
+++ b/www/webapp/src/components/Field/GenericText.vue
@@ -6,8 +6,9 @@
     :value="value"
     :type="type || ''"
     :placeholder="placeholder || (required ? '' : '(optional)')"
-    :hint="hint"
-    persistent-hint
+    :hint="hintWarning(value) !== false && hint"
+    :persistent-hint="hintWarning(value) !== false"
+    :class="hintClass"
     :required="required"
     :rules="[v => !required || !!v || 'Required.'].concat(rules)"
     @input="changed('input', $event)"
@@ -31,6 +32,10 @@ export default {
     hint: {
       type: String,
       default: '',
+    },
+    hintWarning: {
+      type: Function,
+      default: () => null,
     },
     label: {
       type: String,
@@ -61,10 +66,18 @@ export default {
       required: false,
     },
   },
+  data() { return {
+    hintClass: '',
+  }},
   methods: {
     changed(event, e) {
       this.$emit(event, e);
       this.$emit('dirty');
+    },
+  },
+  watch: {
+    value: function() {
+      this.hintClass = this.hintWarning(this.value) ? 'hint-warning' : '';
     },
   },
 };
@@ -90,5 +103,8 @@ export default {
 */
 .v-input--is-disabled {
   pointer-events: none;  /* thanks to https://stackoverflow.com/a/66029445/6867099 */
+}
+.hint-warning .v-messages__message {
+  color: #fb8c00;
 }
 </style>

--- a/www/webapp/src/views/CrudListRecord.vue
+++ b/www/webapp/src/views/CrudListRecord.vue
@@ -53,12 +53,15 @@ export default {
           value: 'subname',
           readonly: true,
           datatype: GenericText.name,
-          fieldProps: () => ({ rules: [
+          fieldProps: () => ({
+            rules: [
               v => !(v.startsWith('.') || v.endsWith('.') || v.includes('..'))
                   || 'Dots must be surrounded by other characters.',
               v => !!v.match(/^([*]|(([*][.])?([a-z0-9_-]{1,63}[.])*[a-z0-9_-]{1,63}))?$/)
                   || 'Allowed characters: a-z, 0-9, and -_. May start with "*." or just be "*".',
-            ] }),
+            ],
+            hintWarning: v => ('.' + v).endsWith('.' + self.$route.params.domain),
+          }),
           searchable: true,
           writeOnCreate: true,
         },


### PR DESCRIPTION
Previously, the hint was shown persistently in standard color (grey). It's now hidden by default, and appears in orange when subname ends with domain name. The message does not block form submission (it is not a validation error).

![image](https://github.com/user-attachments/assets/644815f8-4ff0-4434-9620-798d132475ec)
