### PR TITLE
Replace -X in curl commands

### DIFF
--- a/docs/auth/account.rst
+++ b/docs/auth/account.rst
@@ -41,7 +41,7 @@ You can register an account by sending a ``POST`` request containing your
 email address, a password, and a captcha ID and solution (see `Obtain a
 Captcha`_), like this::
 
-    curl -X POST https://desec.io/api/v1/auth/ \
+    curl https://desec.io/api/v1/auth/ \
         --header "Content-Type: application/json" --data @- <<EOF
         {
           "email": "youremailaddress@example.com",
@@ -108,7 +108,7 @@ Domain Creation during Account Registration
 Along with your account creation request, you can provide a domain name as
 follows::
 
-    curl -X POST https://desec.io/api/v1/auth/ \
+    curl https://desec.io/api/v1/auth/ \
         --header "Content-Type: application/json" --data @- <<EOF
         {
           "email": "youremailaddress@example.com",
@@ -143,7 +143,7 @@ you can ask the API for a token that can be used to authorize subsequent DNS
 management requests. To obtain such a token, send a ``POST`` request with your
 email address and password to the ``/auth/login/`` endpoint::
 
-    curl -X POST https://desec.io/api/v1/auth/login/ \
+    curl https://desec.io/api/v1/auth/login/ \
         --header "Content-Type: application/json" --data @- <<< \
         '{"email": "youremailaddress@example.com", "password": "yourpassword"}'
 
@@ -175,7 +175,7 @@ In case of credential mismatch, the server returns ``403 Permission Denied``.
 To authorize subsequent requests with the new token, set the HTTP ``Authorization``
 header to the token's secret value, prefixed with ``Token``::
 
-    curl -X GET https://desec.io/api/v1/ \
+    curl https://desec.io/api/v1/ \
         --header "Authorization: Token i-T3b1h_OI-H9ab8tRS98stGtURe"
 
 
@@ -222,7 +222,7 @@ Retrieve Account Information
 To request information about your account, send a ``GET`` request to the
 ``/auth/account/`` endpoint::
 
-    curl -X GET https://desec.io/api/v1/auth/account/ \
+    curl https://desec.io/api/v1/auth/account/ \
         --header "Authorization: Token i-T3b1h_OI-H9ab8tRS98stGtURe"
 
 A JSON object representing your user account will be returned::
@@ -292,7 +292,7 @@ In case you forget your password, you can reset it. To do so, send a
 ``POST`` request with your email address and a captcha ID and solution (see
 `Obtain a Captcha`_) to the ``/auth/account/reset-password/`` endpoint::
 
-    curl -X POST https://desec.io/api/v1/auth/account/reset-password/ \
+    curl https://desec.io/api/v1/auth/account/reset-password/ \
         --header "Content-Type: application/json" --data @- <<EOF
         {
           "email": "youremailaddress@example.com",
@@ -311,7 +311,7 @@ password reset, click on that link (which will direct you to our frontend) or
 send a ``POST`` request to this URL, with the new password in
 the payload::
 
-    curl -X POST https://desec.io/api/v1/v/reset-password/<code>/ \
+    curl https://desec.io/api/v1/v/reset-password/<code>/ \
         --header "Content-Type: application/json" --data @- <<< \
         '{"new_password": "yournewpassword"}'
 
@@ -334,7 +334,7 @@ To change the email address associated with your account, send a ``POST``
 request with your email address, your password, and your new email address to
 the ``/auth/account/change-email/`` endpoint::
 
-    curl -X POST https://desec.io/api/v1/auth/account/change-email/ \
+    curl https://desec.io/api/v1/auth/account/change-email/ \
         --header "Content-Type: application/json" --data @- <<EOF
         {
           "email": "youremailaddress@example.com",
@@ -367,7 +367,7 @@ domains from deSEC (see :ref:`deleting-a-domain`).
 To delete your (empty) account, send a ``POST`` request with your email
 address and password to the ``/auth/account/delete/`` endpoint::
 
-    curl -X POST https://desec.io/api/v1/auth/account/delete/ \
+    curl https://desec.io/api/v1/auth/account/delete/ \
         --header "Content-Type: application/json" --data @- <<< \
         '{"email": "youremailaddress@example.com", "password": "yourpassword"}'
 

--- a/docs/auth/tokens.rst
+++ b/docs/auth/tokens.rst
@@ -183,7 +183,7 @@ Creating a Token
 
 To create a new token, issue a ``POST`` request to the tokens endpoint::
 
-    curl -X POST https://desec.io/api/v1/auth/tokens/ \
+    curl https://desec.io/api/v1/auth/tokens/ \
         --header "Authorization: Token mu4W4MHuSc0Hy-GD1h_dnKuZBond" \
         --header "Content-Type: application/json" --data @- <<< \
         '{"name": "my new token"}'
@@ -283,7 +283,7 @@ Listing Tokens
 
 To retrieve a list of all known tokens, issue a ``GET`` request as follows::
 
-    curl -X GET https://desec.io/api/v1/auth/tokens/ \
+    curl https://desec.io/api/v1/auth/tokens/ \
         --header "Authorization: Token mu4W4MHuSc0Hy-GD1h_dnKuZBond"
 
 The server will respond with a list of token objects.  Up to 500 items are
@@ -297,7 +297,7 @@ Retrieving a Specific Token
 To retrieve information about a specific token, issue a ``GET`` request to the
 token's endpoint::
 
-    curl -X GET https://desec.io/api/v1/auth/tokens/{id}/ \
+    curl https://desec.io/api/v1/auth/tokens/{id}/ \
         --header "Authorization: Token mu4W4MHuSc0Hy-GD1h_dnKuZBond"
 
 The response will contain a token object as described under `Token Field
@@ -462,14 +462,14 @@ rest of the API, so is not documented in detail here.
 For example, to retrieve a list of policies for a given token, issue a ``GET``
 request as follows::
 
-    curl -X GET https://desec.io/api/v1/auth/tokens/{id}/policies/rrsets/ \
+    curl https://desec.io/api/v1/auth/tokens/{id}/policies/rrsets/ \
         --header "Authorization: Token mu4W4MHuSc0Hy-GD1h_dnKuZBond"
 
 The server will respond with a list of token policy objects.
 
 To create the default policy, send a request like::
 
-    curl -X POST https://desec.io/api/v1/auth/tokens/{id}/policies/rrsets/ \
+    curl https://desec.io/api/v1/auth/tokens/{id}/policies/rrsets/ \
         --header "Authorization: Token mu4W4MHuSc0Hy-GD1h_dnKuZBond" \
         --header "Content-Type: application/json" --data @- <<< \
         '{"domain": null, "subname": null, "type": null}'
@@ -480,7 +480,7 @@ not given, it is assumed to be ``false``.
 As an example, let's create a policy that only allows manipulating all A
 records for a specific domain::
 
-    curl -X POST https://desec.io/api/v1/auth/tokens/{id}/policies/rrsets/ \
+    curl https://desec.io/api/v1/auth/tokens/{id}/policies/rrsets/ \
         --header "Authorization: Token mu4W4MHuSc0Hy-GD1h_dnKuZBond" \
         --header "Content-Type: application/json" --data @- <<< \
         '{"domain": "example.dedyn.io", "subname": null, "type": "A", "perm_write": true}'

--- a/docs/dns/domains.rst
+++ b/docs/dns/domains.rst
@@ -144,7 +144,7 @@ Creating a Domain
 To create a new domain, issue a ``POST`` request to the ``/api/v1/domains/``
 endpoint, like this::
 
-    curl -X POST https://desec.io/api/v1/domains/ \
+    curl https://desec.io/api/v1/domains/ \
         --header "Authorization: Token {secret}" \
         --header "Content-Type: application/json" --data @- <<< \
         '{"name": "example.com"}'
@@ -183,7 +183,7 @@ Listing Domains
 The ``/api/v1/domains/`` endpoint responds to ``GET`` requests with an array of
 `domain object`_\ s. For example, you may issue the following command::
 
-    curl -X GET https://desec.io/api/v1/domains/ \
+    curl https://desec.io/api/v1/domains/ \
         --header "Authorization: Token {secret}"
 
 to retrieve an overview of the domains you own.  Domains are returned in
@@ -203,7 +203,7 @@ Retrieving a Specific Domain
 To retrieve a domain with a specific name, issue a ``GET`` request with the
 ``name`` appended to the ``domains/`` endpoint, like this::
 
-    curl -X GET https://desec.io/api/v1/domains/{name}/ \
+    curl https://desec.io/api/v1/domains/{name}/ \
         --header "Authorization: Token {secret}"
 
 This will return only one domain (i.e., the response is not a JSON array).
@@ -224,7 +224,7 @@ is also called the "authoritative zone".)
 The responsible domain for a given DNS query name (``qname``) can be retrieved
 by applying a filter on the endpoint used for `Listing Domains`_, like so::
 
-    curl -X GET https://desec.io/api/v1/domains/?owns_qname={qname} \
+    curl https://desec.io/api/v1/domains/?owns_qname={qname} \
         --header "Authorization: Token {secret}"
 
 If your account has a domain that is responsible for the name ``qname``, the
@@ -266,7 +266,7 @@ Exporting a Domain as Zonefile
 To export domain data in zonefile format, send a ``GET`` request to the
 ``zonefile`` endpoint of this domain, i.e. to ``/domains/{name}/zonefile/``::
 
-    curl -X GET https://desec.io/api/v1/domains/{name}/zonefile/ \
+    curl https://desec.io/api/v1/domains/{name}/zonefile/ \
         --header "Authorization: Token {secret}"
 
 Note that this will return a plain-text zonefile format without JSON formatting

--- a/docs/dns/rrsets.rst
+++ b/docs/dns/rrsets.rst
@@ -153,7 +153,7 @@ Creating an RRset
 To create a new RRset, simply issue a ``POST`` request to the
 ``/api/v1/domains/{name}/rrsets/`` endpoint, like this::
 
-    curl -X POST https://desec.io/api/v1/domains/{name}/rrsets/ \
+    curl https://desec.io/api/v1/domains/{name}/rrsets/ \
         --header "Authorization: Token {secret}" \
         --header "Content-Type: application/json" --data @- <<< \
         '{"subname": "www", "type": "A", "ttl": 3600, "records": ["127.0.0.1", "127.0.0.2"]}'
@@ -191,7 +191,7 @@ A common use case is the creation of a ``TLSA`` RRset which carries information
 about the TLS certificate used by the server that the domain points to.  For
 example, to create a ``TLSA`` RRset for ``www.example.com``, you can run::
 
-    curl -X POST https://desec.io/api/v1/domains/{name}/rrsets/ \
+    curl https://desec.io/api/v1/domains/{name}/rrsets/ \
         --header "Authorization: Token {secret}" \
         --header "Content-Type: application/json" --data @- <<EOF
         {
@@ -220,7 +220,7 @@ It is often desirable to create several RRsets at once.  This is achieved by
 sending an array of RRset objects to the ``rrsets/`` endpoint (instead of just
 one), like this::
 
-    curl -X POST https://desec.io/api/v1/domains/{name}/rrsets/ \
+    curl https://desec.io/api/v1/domains/{name}/rrsets/ \
         --header "Authorization: Token {secret}" \
         --header "Content-Type: application/json" --data @- <<EOF
         [
@@ -243,7 +243,7 @@ The ``/api/v1/domains/{name}/rrsets/`` endpoint responds to ``GET`` requests
 with an array of `RRset object`_\ s. For example, you may issue the following
 command::
 
-    curl -X GET https://desec.io/api/v1/domains/{name}/rrsets/ \
+    curl https://desec.io/api/v1/domains/{name}/rrsets/ \
         --header "Authorization: Token {secret}"
 
 to retrieve the contents of a zone that you own.  RRsets are returned in
@@ -668,7 +668,7 @@ Record types with priority field
       etc. as required by the client you are using.  Here's an example of how
       to create a ``TXT`` RRset::
 
-          curl -X POST https://desec.io/api/v1/domains/{name}/rrsets/ \
+          curl https://desec.io/api/v1/domains/{name}/rrsets/ \
               --header "Authorization: Token {secret}" \
               --header "Content-Type: application/json" --data @- <<< \
               '{"type": "TXT", "records": ["\"test value1\"","\"value2\""], "ttl": 3600}'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ pretty-print JSON output, process the data through ``jq``:  ``curl ... | jq .``.
 sometimes do not work. In this case, try moving the request payload in front
 of the ``curl`` call, like this::
 
-    echo {"name": "example.com"} | curl -X POST https://desec.io/api/v1/domains/ --header "Authorization: Token {secret}" --header "Content-Type: application/json" --data @-
+    echo {"name": "example.com"} | curl https://desec.io/api/v1/domains/ --header "Authorization: Token {secret}" --header "Content-Type: application/json" --data @-
 
 
 .. toctree::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -16,7 +16,7 @@ Here's a quick intro how to get started:
 
 #. :ref:`register-account`::
 
-    curl -X POST https://desec.io/api/v1/auth/ \
+    curl https://desec.io/api/v1/auth/ \
         --header "Content-Type: application/json" --data @- <<EOF
         {
           "email": "youremailaddress@example.com",
@@ -36,7 +36,7 @@ Here's a quick intro how to get started:
 
 #. :ref:`log-in`::
 
-    curl -X POST https://desec.io/api/v1/auth/login/ \
+    curl https://desec.io/api/v1/auth/login/ \
         --header "Content-Type: application/json" --data @- <<< \
         '{"email": "youremailaddress@example.com", "password": "yourpassword"}'
 
@@ -50,7 +50,7 @@ Here's a quick intro how to get started:
 
 #. Create a DNS zone::
 
-    curl -X POST https://desec.io/api/v1/domains/ \
+    curl https://desec.io/api/v1/domains/ \
         --header "Authorization: Token {secret}" \
         --header "Content-Type: application/json" --data @- <<< \
         '{"name": "example.com"}'


### PR DESCRIPTION
Based on the Post [Unnecessary use of curl -X](https://daniel.haxx.se/blog/2015/09/11/unnecessary-use-of-curl-x/) is the parameter `-X` unnecessary for `POST` and `GET` calls.

This PR removed the unnecessary `-X` for that examples.