### PR TITLE
fix(docs): token policies are created by POST

### DIFF
--- a/docs/auth/tokens.rst
+++ b/docs/auth/tokens.rst
@@ -481,7 +481,7 @@ request as follows::
 
 The server will respond with a list of token policy objects.
 
-To create the default policy, send a request like::
+To create the default policy, send a ``POST`` request like::
 
     curl https://desec.io/api/v1/auth/tokens/{id}/policies/rrsets/ \
         --header "Authorization: Token mu4W4MHuSc0Hy-GD1h_dnKuZBond" \


### PR DESCRIPTION
87a98e8b8a834d9224a4ce3900c63d0bb7652cf2 made it a bit less obvious that this must be a POST request, in case it's sent with a tool other than curl. :sweat_smile: 