### PR TITLE
allow additional characters in TLDs for CNAME records

### DIFF
--- a/www/webapp/src/components/Field/RecordCNAME.vue
+++ b/www/webapp/src/components/Field/RecordCNAME.vue
@@ -2,7 +2,7 @@
 import { helpers } from 'vuelidate/lib/validators';
 import RecordItem from './RecordItem.vue';
 
-const domain = helpers.regex('domain', /^(([a-zA-Z0-9_\\-]+\.)+[a-zA-Z]{2,})[.]?$/);
+const domain = helpers.regex('domain', /^(([a-zA-Z0-9_\\-]+\.)+[a-zA-Z0-9\\-]{2,})[.]?$/);
 const trailingDot = helpers.regex('trailingDot', /[.]$/);
 
 export default {


### PR DESCRIPTION
I don't really understand what this regex is supposed to be accomplishing. Apparently, the intention is that the validation is only supposed to allow domains that are both syntactically valid and have a valid ICANN TLD, but the TLD validation is not compatible with [punycode TLDs](https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains#Internationalized_generic_top-level_domains) because they have hyphens. This could probably be done better. I just copied the character class from the repeating part to the terminal part.

There doesn't need to be a backend change for this. I've been using punycode TLDs with CNAMEs through the API and by using `$0.click()` in the browser developer tools.