### PR TITLE
Try <a>'ing links

### DIFF
--- a/www/webapp/src/views/CrudList.vue
+++ b/www/webapp/src/views/CrudList.vue
@@ -197,8 +197,15 @@
               v-for="(column, id) in columns"
               #[column.name]="itemFieldProps"
             >
+              <router-link
+                v-if="cellUsesPlainText(column, rawItem(itemFieldProps.item)) && column.link"
+                :key="`${id}-link`"
+                class="crud-readonly-value crud-link"
+                :to="column.link(rawItem(itemFieldProps.item))"
+                @click.stop
+              >{{ readonlyDisplayValue(column, rawItem(itemFieldProps.item)) }}</router-link>
               <div
-                v-if="cellUsesPlainText(column, rawItem(itemFieldProps.item))"
+                v-else-if="cellUsesPlainText(column, rawItem(itemFieldProps.item))"
                 :key="`${id}-readonly`"
                 class="crud-readonly-value"
                 v-text="readonlyDisplayValue(column, rawItem(itemFieldProps.item))"
@@ -840,6 +847,12 @@ export default {
   line-height: 1.5;
   min-height: 56px;
   padding: 20px 0 4px;
+}
+/* a real link, so that it can be opened in a new tab, but looking like the rest
+   of the row (App.vue underlines it on hover, like any other link) */
+.v-application a.crud-link {
+  color: inherit !important;
+  text-decoration: none;
 }
 </style>
 

--- a/www/webapp/src/views/CrudListDomain.vue
+++ b/www/webapp/src/views/CrudListDomain.vue
@@ -46,6 +46,7 @@ export default {
             writeOnCreate: true,
             datatype: GenericText.name,
             searchable: true,
+            link: item => ({name: 'domain', params: {domain: item.name}}),
           },
           published: {
             name: 'item.published',


### PR DESCRIPTION
Hope this works, for #1192. 

  CrudList.vue — The column template now checks for a column.link function. If present, the column content is wrapped in a <router-link> (renders as <a>). The @click.native.stop prevents the click from bubbling up to the row's @click:row handler, so regular clicks navigate via the link, and ctrl-click / middle-click / right-click all work natively. Columns without link render exactly as before.               
                                                                                                                                                                                                                                                                                                                                                                                                                                                    CrudListDomain.vue — Added link: (item) => ({name: 'domain', params: {domain: item.name}}) to the name column. This generates the /domains/example.com URL as a proper <a> href.             
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 The existing handleRowClick is kept, so clicking anywhere else on the row (e.g. the "Published" column) still navigates as before. But now the domain name is a real link with full browser link semantics: right-click menu, open in new tab, ctrl/cmd-click, middle-click, and URL preview in the status bar.                                                                                                                      