### PR TITLE
fix(www): Update SSE link

### DIFF
--- a/www/webapp/index.html
+++ b/www/webapp/index.html
@@ -13,7 +13,7 @@
       <h1>Modern DNS Hosting for Everyone</h1>
       <p>
         deSEC is a <strong>free DNS hosting</strong> service, <strong>designed with security in mind</strong>.<br>
-        Running on <strong>open-source software</strong> and <strong>supported by <a href="https://securesystems.de/">SSE</a></strong>,
+        Running on <strong>open-source software</strong> and <strong>supported by <a href="https://systemsecurity.com/">SSE</a></strong>,
         deSEC is free for everyone to use.
       </p>
       <h2>🛑 Warning</h2>

--- a/www/webapp/src/views/HomePage.vue
+++ b/www/webapp/src/views/HomePage.vue
@@ -11,7 +11,7 @@
               deSEC is a <strong>free DNS hosting</strong> service, <strong>designed with security in mind</strong>.
             </p>
             <p>
-              Running on <strong>open-source software</strong> and <strong>supported by <a href="https://securesystems.de/">SSE</a></strong>,
+              Running on <strong>open-source software</strong> and <strong>supported by <a href="https://systemsecurity.com/">SSE</a></strong>,
               deSEC is free for everyone to use.
             </p>
           </div>


### PR DESCRIPTION
Hello :)
Today I came across that the link to SSE triggers a certificate warning at the redirection from securesystems.de to systemsecurity.com. So I decided to make this my first contribution on GitHub for my favorite DNS provider :D 

Edit: I am sorry for the AI clutter, it was unintentional. I wrote this text myself and I rather make mistakes and learn from it :) 