### PR TITLE
Adds support for managing token policies using the webapp

### DIFF
--- a/www/webapp/src/components/Field/RRSetType.vue
+++ b/www/webapp/src/components/Field/RRSetType.vue
@@ -78,6 +78,7 @@ export default {
     input(event) {
       this.$emit('update:modelValue', event);
       this.$emit('input', event);
+      this.$emit('dirty');
     },
   },
 };

--- a/www/webapp/src/components/Field/RRSetType.vue
+++ b/www/webapp/src/components/Field/RRSetType.vue
@@ -4,6 +4,7 @@
     :disabled="disabled || readonly"
     :error-messages="errorMessages"
     :hint="hint"
+    :placeholder="placeholder"
     :persistent-hint="!readonly"
     :model-value="inputValue"
     :items="types"
@@ -37,6 +38,10 @@ export default {
     hint: {
       type: String,
       default: 'You can also enter other types. For a full list, check the documentation.',
+    },
+    placeholder: {
+      type: String,
+      default: undefined,
     },
     required: {
       type: Boolean,

--- a/www/webapp/src/components/Field/RRSetType.vue
+++ b/www/webapp/src/components/Field/RRSetType.vue
@@ -3,7 +3,7 @@
     :label="label"
     :disabled="disabled || readonly"
     :error-messages="errorMessages"
-    hint="You can also enter other types. For a full list, check the documentation."
+    :hint="hint"
     :persistent-hint="!readonly"
     :model-value="inputValue"
     :items="types"
@@ -33,6 +33,10 @@ export default {
     readonly: {
       type: Boolean,
       required: false,
+    },
+    hint: {
+      type: String,
+      default: 'You can also enter other types. For a full list, check the documentation.',
     },
     required: {
       type: Boolean,

--- a/www/webapp/src/router/index.js
+++ b/www/webapp/src/router/index.js
@@ -144,6 +144,12 @@ const routes = [
     meta: {guest: false},
   },
   {
+    path: '/tokens/:tokenId/policies',
+    name: 'tokenPolicies',
+    component: () => import('@/views/CrudListTokenPolicy.vue'),
+    meta: {guest: false},
+  },
+  {
     path: '/domains',
     name: 'domains',
     component: lazy(() => import('@/views/CrudListDomain.vue')),

--- a/www/webapp/src/views/CrudListToken.vue
+++ b/www/webapp/src/views/CrudListToken.vue
@@ -6,10 +6,23 @@ import GenericCheckbox from "@/components/Field/GenericCheckbox.vue";
 import RecordList from "@/components/Field/RecordList.vue";
 import GenericSwitchbox from "@/components/Field/GenericSwitchbox.vue";
 import TimeAgo from "@/components/Field/TimeAgo.vue";
+import {mdiShieldLock} from "@mdi/js";
 
 export default {
   name: 'CrudListToken',
   extends: CrudList,
+  computed: {
+    actions() {
+      return {
+        policies: {
+          go: (item) => this.$router.push({ name: 'tokenPolicies', params: { tokenId: item.id }, query: item.name ? { name: item.name } : {} }),
+          if: this.showAdvanced,
+          icon: mdiShieldLock,
+          tooltip: 'Policies',
+        },
+      };
+    },
+  },
   data() {
     return {
         creatable: true,

--- a/www/webapp/src/views/CrudListTokenPolicy.vue
+++ b/www/webapp/src/views/CrudListTokenPolicy.vue
@@ -43,7 +43,7 @@ export default {
           writeOnCreate: true,
           datatype: GenericText.name,
           searchable: true,
-          fieldProps: () => ({ placeholder: '(any domain)' }),
+          fieldProps: () => ({ placeholder: '(any domain)', hint: 'Leave empty to match any domain.' }),
         },
         subname: {
           name: 'item.subname',
@@ -56,7 +56,7 @@ export default {
           writeOnCreate: true,
           datatype: GenericText.name,
           searchable: true,
-          fieldProps: () => ({ placeholder: '(any subname)' }),
+          fieldProps: () => ({ placeholder: '(any subname)', hint: 'Leave empty to match any subname.' }),
         },
         type: {
           name: 'item.type',
@@ -69,7 +69,7 @@ export default {
           writeOnCreate: true,
           datatype: 'RRSetType',
           searchable: true,
-          fieldProps: (item) => ({ value: item.type || '', hint: 'Leave empty to match any record type. You can also enter types not listed.' }),
+          fieldProps: (item) => ({ value: item.type || '', placeholder: '(any type)', hint: 'Leave empty to match any record type. You can also enter types not listed.' }),
         },
         perm_write: {
           name: 'item.perm_write',

--- a/www/webapp/src/views/CrudListTokenPolicy.vue
+++ b/www/webapp/src/views/CrudListTokenPolicy.vue
@@ -1,0 +1,106 @@
+<script>
+import CrudList from './CrudList.vue';
+import GenericText from '@/components/Field/GenericText.vue';
+import GenericSwitchbox from '@/components/Field/GenericSwitchbox.vue';
+
+export default {
+  name: 'CrudListTokenPolicy',
+  extends: CrudList,
+  data() {
+    const self = this;
+    return {
+      creatable: true,
+      updatable: true,
+      destroyable: true,
+      headlines: {
+        table: `Policies for token ${self.$route.query.name ? `${self.$route.query.name} (${self.$route.params.tokenId})` : self.$route.params.tokenId}`,
+        create: 'Add Policy',
+        destroy: 'Delete Policy',
+      },
+      texts: {
+        banner: () => (
+          'Policies restrict DNS write access for this token. A default policy (all fields empty) must exist before specific policies can be added. ' +
+          '<a href="https://desec.readthedocs.io/en/latest/auth/tokens.html#token-scoping-policies" target="_blank">Documentation</a>'
+        ),
+        create: () => 'Add a policy. Leave domain, subname, and type empty to create the default (deny-all) policy.',
+        destroy: p => {
+          const domain = p.domain || 'any domain';
+          const subname = p.subname || 'any subname';
+          const type = p.type || 'any type';
+          const write = p.perm_write ? 'write allowed' : 'write denied';
+          return `Delete policy (${domain}, ${subname}, ${type}, ${write})?`;
+        },
+      },
+      columns: {
+        domain: {
+          name: 'item.domain',
+          text: 'Domain',
+          align: 'left',
+          sortable: true,
+          value: 'domain',
+          readonly: false,
+          required: false,
+          writeOnCreate: true,
+          datatype: GenericText.name,
+          searchable: true,
+          fieldProps: () => ({ placeholder: '(any domain)' }),
+        },
+        subname: {
+          name: 'item.subname',
+          text: 'Subname',
+          align: 'left',
+          sortable: true,
+          value: 'subname',
+          readonly: false,
+          required: false,
+          writeOnCreate: true,
+          datatype: GenericText.name,
+          searchable: true,
+          fieldProps: () => ({ placeholder: '(any subname)' }),
+        },
+        type: {
+          name: 'item.type',
+          text: 'Type',
+          align: 'left',
+          sortable: true,
+          value: 'type',
+          readonly: false,
+          required: false,
+          writeOnCreate: true,
+          datatype: 'RRSetType',
+          searchable: true,
+          fieldProps: (item) => ({ value: item.type || '', hint: 'Leave empty to match any record type. You can also enter types not listed.' }),
+        },
+        perm_write: {
+          name: 'item.perm_write',
+          text: 'Write',
+          align: 'left',
+          sortable: true,
+          value: 'perm_write',
+          readonly: false,
+          writeOnCreate: true,
+          datatype: GenericSwitchbox.name,
+          searchable: false,
+        },
+      },
+      paths: {
+        list: 'auth/tokens/::{tokenId}/policies/rrsets/',
+        create: 'auth/tokens/::{tokenId}/policies/rrsets/',
+        delete: 'auth/tokens/::{tokenId}/policies/rrsets/:{id}/',
+        update: 'auth/tokens/::{tokenId}/policies/rrsets/:{id}/',
+      },
+      itemDefaults: () => ({ domain: '', subname: '', type: '', perm_write: false }),
+      precreate() {
+        this.createDialogItem.domain = this.createDialogItem.domain || null;
+        this.createDialogItem.subname = this.createDialogItem.subname || null;
+        this.createDialogItem.type = this.createDialogItem.type || null;
+      },
+      preupdate(item) {
+        item.domain = item.domain || null;
+        item.subname = item.subname || null;
+        item.type = item.type || null;
+      },
+    };
+  },
+};
+</script>


### PR DESCRIPTION
I made the basics for managing the token policies from the website, but without too much extra added features.
From the issue here https://github.com/desec-io/desec-stack/issues/868 , it would be nice-to-have a dropdown/autocomplete of domains, but I think if it is initially just kept simple, then it could be added at a later point if someone finds that it's required.

As it is now, I tested it against desec.io and it worked just fine, no issues! I'm amazed how easy it was to add this management to the webapp.

Any suggestions/changes are appreciated :)

I tested it against desec.io by doing

```patch
diff --git a/www/webapp/vite.config.js b/www/webapp/vite.config.js
index 9ebfe90..5873c29 100644
--- a/www/webapp/vite.config.js
+++ b/www/webapp/vite.config.js
@@ -34,6 +34,12 @@ export default defineConfig({
     ],
     server: {
         port: 8080,
+        proxy: {
+            '/api': {
+                target: 'https://desec.io',
+                changeOrigin: true,
+            },
+        },
     },
     resolve: {
         alias: [{
```

<img width="1228" height="631" alt="image" src="https://github.com/user-attachments/assets/1596baf8-6a31-44e4-9fb1-72a8ce1579f3" />

<img width="1215" height="712" alt="image" src="https://github.com/user-attachments/assets/e441c535-e9b5-4302-b23a-8724ff792ab8" />

<img width="1177" height="563" alt="image" src="https://github.com/user-attachments/assets/23d82391-5712-4758-a949-f88e765f7c6f" />

<img width="2129" height="116" alt="image" src="https://github.com/user-attachments/assets/e99f0cb6-ff71-4fdf-b189-67b32909d781" />



EDIT: I used LLMs to assist me with this PR :)