### PR TITLE
fix(nsmaster): allow larger request body

### DIFF
--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -191,8 +191,7 @@ TASK_CONFIG = {  # The first entry is the default queue
 }
 
 # pdns accepts request payloads of this size.
-# This will hopefully soon be configurable: https://github.com/PowerDNS/pdns/pull/7550
-PDNS_MAX_BODY_SIZE = 16 * 1024 * 1024
+PDNS_MAX_BODY_SIZE = 32 * 1024 * 1024
 
 # SEPA direct debit settings
 SEPA = {

--- a/nsmaster/conf/pdns.conf.var
+++ b/nsmaster/conf/pdns.conf.var
@@ -13,7 +13,7 @@ version-string=powerdns
 webserver=yes
 webserver-address=${DESECSTACK_IPV4_REAR_PREFIX16}.1.12
 webserver-allow-from=${DESECSTACK_IPV4_REAR_PREFIX16}.1.10
-webserver-max-bodysize=16
+webserver-max-bodysize=32
 carbon-server=${DESECSTACK_NSMASTER_CARBONSERVER}
 carbon-ourname=${DESECSTACK_NSMASTER_CARBONOURNAME}
 


### PR DESCRIPTION
As our number of domains grew, this is now needed to provision the catalog zone, which is done when API container (re)starts. We currently have a hotfix in production.