### PR TITLE
feat(webapp): Use fixed Nodejs version v24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: 18
+        node-version: 24
     - name: Install webapp dependencies
       run: npm install
       working-directory: www/webapp

--- a/www/Dockerfile
+++ b/www/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts AS webapp
+FROM node:24-slim AS webapp
 RUN \
   apt-get update \
   && apt-get -y install gettext-base \

--- a/www/webapp/package.json
+++ b/www/webapp/package.json
@@ -14,14 +14,14 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=18"
+    "node": ">=24"
   },
   "dependencies": {
     "@fontsource/roboto": "^5.0.3",
     "@mdi/js": "~7.4.47",
     "@vuelidate/core": "^2.0.3",
     "@vuelidate/validators": "^2.0.4",
-    "axios": "^1.4.0",
+    "axios": "^1.19.0",
     "date-fns": "^4.1.0",
     "pinia": "^2.0.30",
     "vue": "^3.4.19",


### PR DESCRIPTION
Node 24 is current supported version.

Lts version in docker build can break. Because Lts changes over time.

## Reference

mentioned in #1219