### PR TITLE
Fix stranded domain deletion (#1218)

### DIFF
--- a/api/desecapi/exception_handlers.py
+++ b/api/desecapi/exception_handlers.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from rest_framework.views import exception_handler as drf_exception_handler
 
 from desecapi import metrics
-from desecapi.exceptions import PDNSException
+from desecapi.exceptions import ChangeTrackerException, PDNSException
 
 
 def exception_handler(exc, context):
@@ -39,6 +39,7 @@ def exception_handler(exc, context):
         IntegrityError: _409,
         OSError: _500,  # OSError happens on system-related errors, like full disk or getaddrinfo() failure.
         PDNSException: _500,  # nslord/nsmaster returned an error
+        ChangeTrackerException: _500,  # commit to nslord/nsmaster/PCH failed
     }
 
     for exception_class, handler in handlers.items():

--- a/api/desecapi/exception_handlers.py
+++ b/api/desecapi/exception_handlers.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from rest_framework.views import exception_handler as drf_exception_handler
 
 from desecapi import metrics
-from desecapi.exceptions import ChangeTrackerException, PDNSException
+from desecapi.exceptions import ChangeTrackerException, PCHException, PDNSException
 
 
 def exception_handler(exc, context):
@@ -39,6 +39,7 @@ def exception_handler(exc, context):
         IntegrityError: _409,
         OSError: _500,  # OSError happens on system-related errors, like full disk or getaddrinfo() failure.
         PDNSException: _500,  # nslord/nsmaster returned an error
+        PCHException: _500,  # PCH returned an error
         ChangeTrackerException: _500,  # commit to nslord/nsmaster/PCH failed
     }
 

--- a/api/desecapi/exceptions.py
+++ b/api/desecapi/exceptions.py
@@ -34,6 +34,10 @@ class PCHException(ExternalAPIException):
     pass
 
 
+class ChangeTrackerException(Exception):
+    """A change could not be committed to pdns/PCH; the database has been rolled back."""
+
+
 class ConcurrencyException(APIException):
     status_code = status.HTTP_429_TOO_MANY_REQUESTS
     default_detail = "Too many concurrent requests."

--- a/api/desecapi/pdns.py
+++ b/api/desecapi/pdns.py
@@ -261,8 +261,8 @@ def create_zone_master(name):
 
 
 def delete_zone(name, server):
-    # Tolerate 404 so that deletion stays idempotent: a zone left behind by a partially
-    # applied deletion must not block the retry that clears the corresponding API state.
+    # Tolerate 404: a zone already removed by a partially applied deletion must not block
+    # the retry that clears the leftover API state.
     _pdns_delete(server, "/zones/" + pdns_id(name), tolerate=(404,))
 
 

--- a/api/desecapi/pdns.py
+++ b/api/desecapi/pdns.py
@@ -90,7 +90,7 @@ def gethostbyname_cached(host):
 
 
 def _pdns_request(
-    method, *, server, path, data=None, accept="application/json", **kwargs
+    method, *, server, path, data=None, accept="application/json", tolerate=(), **kwargs
 ):
     if data is not None:
         data = json.dumps(data)
@@ -109,8 +109,10 @@ def _pdns_request(
         metrics.get("desecapi_pdns_request_failure").labels(
             method, path, r.status_code
         ).inc()
-        raise PDNSException(response=r)
-    metrics.get("desecapi_pdns_request_success").labels(method, r.status_code).inc()
+        if r.status_code not in tolerate:
+            raise PDNSException(response=r)
+    else:
+        metrics.get("desecapi_pdns_request_success").labels(method, r.status_code).inc()
     return r
 
 
@@ -259,15 +261,17 @@ def create_zone_master(name):
 
 
 def delete_zone(name, server):
-    _pdns_delete(server, "/zones/" + pdns_id(name))
+    # Tolerate 404 so that deletion stays idempotent: a zone left behind by a partially
+    # applied deletion must not block the retry that clears the corresponding API state.
+    _pdns_delete(server, "/zones/" + pdns_id(name), tolerate=(404,))
 
 
 def delete_zone_lord(name):
-    _pdns_delete(NSLORD, "/zones/" + pdns_id(name))
+    delete_zone(name, NSLORD)
 
 
 def delete_zone_master(name):
-    _pdns_delete(NSMASTER, "/zones/" + pdns_id(name))
+    delete_zone(name, NSMASTER)
 
 
 def update_zone(name, data):

--- a/api/desecapi/pdns_change_tracker.py
+++ b/api/desecapi/pdns_change_tracker.py
@@ -4,6 +4,7 @@ from django.db.transaction import atomic
 from django.utils import timezone
 
 from desecapi import pch, pdns
+from desecapi.exceptions import ChangeTrackerException
 from desecapi.models import RRset, RR, Domain
 
 
@@ -250,7 +251,7 @@ class PDNSChangeTracker:
                     axfr_required.add(change.domain_name)
             except Exception as e:
                 self.transaction.__exit__(type(e), e, e.__traceback__)
-                exc = ValueError(
+                exc = ChangeTrackerException(
                     f"For changes {list(map(str, changes))}, {type(e)} occurred during {change}: {str(e)}"
                 )
                 raise exc from e

--- a/api/desecapi/pdns_change_tracker.py
+++ b/api/desecapi/pdns_change_tracker.py
@@ -255,7 +255,7 @@ class PDNSChangeTracker:
                 context = f"For changes {list(map(str, changes))}, {type(e)} occurred during {change}"
                 if isinstance(e, APIException):
                     # These already carry the status code the client needs to see, such as 413
-                    # for RequestEntityTooLarge. Keep the context as a note on the traceback.
+                    # for RequestEntityTooLarge, so don't mask it behind a generic 500.
                     e.add_note(context)
                     raise
                 raise ChangeTrackerException(f"{context}: {str(e)}") from e

--- a/api/desecapi/pdns_change_tracker.py
+++ b/api/desecapi/pdns_change_tracker.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db.models.signals import post_save, post_delete
 from django.db.transaction import atomic
 from django.utils import timezone
+from rest_framework.exceptions import APIException
 
 from desecapi import pch, pdns
 from desecapi.exceptions import ChangeTrackerException
@@ -251,10 +252,13 @@ class PDNSChangeTracker:
                     axfr_required.add(change.domain_name)
             except Exception as e:
                 self.transaction.__exit__(type(e), e, e.__traceback__)
-                exc = ChangeTrackerException(
-                    f"For changes {list(map(str, changes))}, {type(e)} occurred during {change}: {str(e)}"
-                )
-                raise exc from e
+                context = f"For changes {list(map(str, changes))}, {type(e)} occurred during {change}"
+                if isinstance(e, APIException):
+                    # These already carry the status code the client needs to see, such as 413
+                    # for RequestEntityTooLarge. Keep the context as a note on the traceback.
+                    e.add_note(context)
+                    raise
+                raise ChangeTrackerException(f"{context}: {str(e)}") from e
 
         self.transaction.__exit__(None, None, None)
 

--- a/api/desecapi/tests/base.py
+++ b/api/desecapi/tests/base.py
@@ -351,6 +351,20 @@ class MockPDNSTestCase(APITestCase):
         }
 
     @classmethod
+    def request_pdns_zone_delete_404(cls, name=None, ns="LORD"):
+        request = cls.request_pdns_zone_delete(name=name, ns=ns)
+        request["status"] = 404
+        request["body"] = json.dumps({"error": "Could not find domain"})
+        return request
+
+    @classmethod
+    def request_pdns_zone_delete_500(cls, name=None, ns="LORD"):
+        request = cls.request_pdns_zone_delete(name=name, ns=ns)
+        request["status"] = 500
+        request["body"] = json.dumps({"error": "Internal Server Error"})
+        return request
+
+    @classmethod
     def request_pdns_zone_update(cls, name=None):
         return {
             "method": "PATCH",

--- a/api/desecapi/tests/test_domains.py
+++ b/api/desecapi/tests/test_domains.py
@@ -285,9 +285,8 @@ class DomainOwnerTestCase1(DomainOwnerTestCase):
         self.assertStatus(response, status.HTTP_404_NOT_FOUND)
 
     def test_delete_my_domain_retry_after_partial_pdns_failure(self):
-        # A deletion that fails at nsmaster rolls the database back, but the nslord zone stays
-        # gone. The retry then hits a zone that no longer exists and must still succeed,
-        # otherwise the domain is stranded and keeps occupying a slot against limit_domains.
+        # A retried deletion must succeed against a zone the first attempt already removed,
+        # or the domain stays stranded and keeps occupying a slot against limit_domains.
         url = self.reverse("v1:domain-detail", name=self.my_domain.name)
         self.client.raise_request_exception = False
 
@@ -310,8 +309,8 @@ class DomainOwnerTestCase1(DomainOwnerTestCase):
             self.assertFalse(Domain.objects.filter(pk=self.my_domain.pk).exists())
 
     def test_delete_my_domain_pdns_failure_renders_json(self):
-        # Clients parse error bodies, so a failed commit must stay within the API's JSON
-        # error contract rather than falling through to Django's HTML error page.
+        # A failed commit must stay within the API's JSON error contract rather than falling
+        # through to Django's HTML error page.
         url = self.reverse("v1:domain-detail", name=self.my_domain.name)
         self.client.raise_request_exception = False
 

--- a/api/desecapi/tests/test_domains.py
+++ b/api/desecapi/tests/test_domains.py
@@ -876,8 +876,8 @@ import-me.example RRSIG A 13 2 3600 20220324000000 20220303000000 40316 @ 4wj6Zr
     def test_create_domain_atomicity(self):
         name = self.random_domain_name()
         with self.assertRequests(self.request_pdns_zone_create_422()):
-            with self.assertRaises(ValueError):
-                self.client.post(self.reverse("v1:domain-list"), {"name": name})
+            response = self.client.post(self.reverse("v1:domain-list"), {"name": name})
+            self.assertStatus(response, status.HTTP_500_INTERNAL_SERVER_ERROR)
             self.assertFalse(Domain.objects.filter(name=name).exists())
 
     def test_create_domain_punycode(self):

--- a/api/desecapi/tests/test_domains.py
+++ b/api/desecapi/tests/test_domains.py
@@ -284,6 +284,45 @@ class DomainOwnerTestCase1(DomainOwnerTestCase):
         response = self.client.get(url)
         self.assertStatus(response, status.HTTP_404_NOT_FOUND)
 
+    def test_delete_my_domain_retry_after_partial_pdns_failure(self):
+        # A deletion that fails at nsmaster rolls the database back, but the nslord zone stays
+        # gone. The retry then hits a zone that no longer exists and must still succeed,
+        # otherwise the domain is stranded and keeps occupying a slot against limit_domains.
+        url = self.reverse("v1:domain-detail", name=self.my_domain.name)
+        self.client.raise_request_exception = False
+
+        with self.assertRequests(
+            self.request_pdns_zone_delete(name=self.my_domain.name, ns="LORD"),
+            self.request_pdns_zone_delete_500(name=self.my_domain.name, ns="MASTER"),
+        ):
+            response = self.client.delete(url)
+            self.assertStatus(response, status.HTTP_500_INTERNAL_SERVER_ERROR)
+            self.assertTrue(Domain.objects.filter(pk=self.my_domain.pk).exists())
+
+        with self.assertRequests(
+            self.request_pdns_zone_delete_404(name=self.my_domain.name, ns="LORD"),
+            self.request_pdns_zone_delete(name=self.my_domain.name, ns="MASTER"),
+            self.request_pdns_update_catalog(),
+            self.request_pch_zone_delete(name=self.my_domain.name),
+        ):
+            response = self.client.delete(url)
+            self.assertStatus(response, status.HTTP_204_NO_CONTENT)
+            self.assertFalse(Domain.objects.filter(pk=self.my_domain.pk).exists())
+
+    def test_delete_my_domain_pdns_failure_renders_json(self):
+        # Clients parse error bodies, so a failed commit must stay within the API's JSON
+        # error contract rather than falling through to Django's HTML error page.
+        url = self.reverse("v1:domain-detail", name=self.my_domain.name)
+        self.client.raise_request_exception = False
+
+        with self.assertRequests(
+            self.request_pdns_zone_delete_500(name=self.my_domain.name, ns="LORD"),
+        ):
+            response = self.client.delete(url)
+
+        self.assertStatus(response, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response["Content-Type"], "application/json")
+
     def test_delete_my_domain_policy_constraints(self):
         policy_sets = [
             ([dict(domain=None, subname=None, type=None, perm_write=True)], True),

--- a/api/desecapi/tests/test_pdns_change_tracker.py
+++ b/api/desecapi/tests/test_pdns_change_tracker.py
@@ -1,5 +1,6 @@
 from django.utils import timezone
 
+from desecapi.exceptions import ChangeTrackerException
 from desecapi.models import RRset, RR, Domain
 from desecapi.pdns_change_tracker import PDNSChangeTracker
 from desecapi.tests.base import DesecTestCase
@@ -34,7 +35,7 @@ class PdnsChangeTrackerTestCase(DesecTestCase):
         tracker = PDNSChangeTracker()
         tracker.__enter__()
         tracker._rr_set_updated(RRset(domain=self.empty_domain, subname="", type="A"))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ChangeTrackerException):
             tracker.__exit__(None, None, None)
 
 

--- a/api/desecapi/tests/test_rrsets.py
+++ b/api/desecapi/tests/test_rrsets.py
@@ -499,6 +499,15 @@ class AuthenticatedRRSetTestCase(AuthenticatedRRSetBaseTestCase):
             str(response.data),
         )
 
+    def test_create_my_rr_sets_exceeding_pdns_body_size(self):
+        # The payload is rejected before it reaches pdns, so the client must see the 413 that
+        # RequestEntityTooLarge declares instead of a generic server error.
+        data = {"records": ["1.2.3.4"], "ttl": 3600, "type": "A", "subname": "name"}
+        with self.settings(PDNS_MAX_BODY_SIZE=1):
+            with self.assertRequests():
+                response = self.client.post_rr_set(self.my_empty_domain.name, **data)
+        self.assertStatus(response, status.HTTP_413_REQUEST_ENTITY_TOO_LARGE)
+
     def test_create_my_rr_sets_twice(self):
         data = {"records": ["1.2.3.4"], "ttl": 3660, "type": "A"}
         with self.assertRequests(

--- a/api/desecapi/tests/test_rrsets.py
+++ b/api/desecapi/tests/test_rrsets.py
@@ -500,8 +500,7 @@ class AuthenticatedRRSetTestCase(AuthenticatedRRSetBaseTestCase):
         )
 
     def test_create_my_rr_sets_exceeding_pdns_body_size(self):
-        # The payload is rejected before it reaches pdns, so the client must see the 413 that
-        # RequestEntityTooLarge declares instead of a generic server error.
+        # The payload never reaches pdns, so the client must see 413 rather than a 500.
         data = {"records": ["1.2.3.4"], "ttl": 3600, "type": "A", "subname": "name"}
         with self.settings(PDNS_MAX_BODY_SIZE=1):
             with self.assertRequests():


### PR DESCRIPTION
## What

- Fixes #1218 
- Fixes HTTP 500s surfacing as Django HTML errors instead of JSON
- Fixes HTTP 500s when RequestEntityTooLarge should give HTTP 413

Does not introduce a two-phase commit:

- #196 

Let me know if you would rather have that than these fixes.

Or if you would like to have the two-phase commit afterwards.

## Pull request structure

The first commit contains tests that currently fail.

Subsequent commits fix those tests.

## Cleanup

I would love to have my account `simon+test@simonshine.dk` unbricked from the following undeletable domains:

- `desec-rs-test-domain-18c996ffee6f27be.dedyn.io`
- `desec-rs-test-apex-18c996e967092783.dedyn.io`
- `desec-rs-test-import-18c996db68330be0.dedyn.io`
- `desec-rs-test-apex-18c996db6834403f.dedyn.io`
- `desec-rs-test-gone-18c9a5fd7eaa9309.dedyn.io`
