### PR TITLE
chore(docs): bump dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-24.04
+  os: ubuntu-26.04
   tools:
-    python: "3.12"
+    python: "3.14"
 
 python:
   install:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
-sphinx-rtd-theme
+sphinx==9.*
+sphinx-rtd-theme==3.*


### PR DESCRIPTION
Restrict package dependencies to current mayor.
Bump python and OS.