### PR TITLE
feat(www): drop DHE TLS ciphers

### DIFF
--- a/www/conf/conf.d/ssl.conf
+++ b/www/conf/conf.d/ssl.conf
@@ -1,9 +1,9 @@
-# generated 2025-07-21, Mozilla Guideline v5.4, nginx 1.29.0, OpenSSL 3.5.0, intermediate config
-# https://ssl-config.mozilla.org/#server=nginx&version=1.29.0&config=intermediate&openssl=3.5.0&guideline=5.4
+# generated 2026-08-14, TLSRef Guideline v6.0, nginx 1.31.3, OpenSSL 3.5.7, intermediate config, gitrev=1b22dc6
+# https://configurator.tlsref.org/#server=nginx&version=1.31.3&config=intermediate&openssl=3.5.7&guideline=6.0
 ssl_protocols TLSv1.2 TLSv1.3;
-ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+ssl_ecdh_curve X25519MLKEM768:X25519:prime256v1:secp384r1;
+ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;
 ssl_prefer_server_ciphers off;
-ssl_dhparam /etc/nginx/dhparam.pem;
 
 # see also ssl_session_ticket_key alternative to stateful session cache
 ssl_session_timeout 1d;


### PR DESCRIPTION
Update nginx TLS config to TLSRef v6.0.
SSL version according to current nginx docker.

### Reference

closes #1189
