### PR TITLE
tests(e2e2): cover the "..." RRset endpoint and bulk request ordering

### DIFF
--- a/api/desecapi/tests/base.py
+++ b/api/desecapi/tests/base.py
@@ -87,24 +87,24 @@ class DesecAPIClient(APIClient):
 
     def get_rr_set(self, domain_name, subname, type_):
         return self.get(
-            self.reverse("v1:rrset@", name=domain_name, subname=subname, type=type_)
+            self.reverse("v1:rrset", name=domain_name, subname=subname, type=type_)
         )
 
     def put_rr_set(self, domain_name, subname, type_, data):
         return self.put(
-            self.reverse("v1:rrset@", name=domain_name, subname=subname, type=type_),
+            self.reverse("v1:rrset", name=domain_name, subname=subname, type=type_),
             data,
         )
 
     def patch_rr_set(self, domain_name, subname, type_, data):
         return self.patch(
-            self.reverse("v1:rrset@", name=domain_name, subname=subname, type=type_),
+            self.reverse("v1:rrset", name=domain_name, subname=subname, type=type_),
             data,
         )
 
     def delete_rr_set(self, domain_name, subname, type_):
         return self.delete(
-            self.reverse("v1:rrset@", name=domain_name, subname=subname, type=type_)
+            self.reverse("v1:rrset", name=domain_name, subname=subname, type=type_)
         )
 
     # TODO add and use {post,get,delete,...}_domain

--- a/api/desecapi/tests/test_rrsets.py
+++ b/api/desecapi/tests/test_rrsets.py
@@ -1389,6 +1389,28 @@ class AuthenticatedRRSetTestCase(AuthenticatedRRSetBaseTestCase):
             )
             self.assertStatus(response, status.HTTP_404_NOT_FOUND)
 
+    def test_rr_set_url_forms(self):
+        # A subname can be written plainly or terminated with `...`. The zone
+        # apex has no plain form (`rrsets//{type}/` does not survive URL
+        # normalization) and is written as `@` or as `...`. Every spelling
+        # available for a subname addresses the same RRset.
+        base = self.reverse("v1:rrsets", name=self.my_rr_set_domain.name)
+        for subname in ["", "test", "*", "bar.baz", "_bar"]:
+            with self.subTest(subname=subname):
+                urls = [f"{base}{subname}.../A/"]
+                urls.append(f"{base}@/A/" if not subname else f"{base}{subname}/A/")
+                responses = [self.client.get(url) for url in urls]
+                for response in responses:
+                    self.assertStatus(response, status.HTTP_200_OK)
+                    self.assertEqual(response.data["subname"], subname)
+                self.assertEqual(responses[0].data, responses[1].data)
+
+    def test_rr_set_url_subname_at_form_removed(self):
+        # `{subname}@` was never documented and is no longer routed; it falls
+        # through to the plain form, where it is not a valid subname.
+        base = self.reverse("v1:rrsets", name=self.my_rr_set_domain.name)
+        self.assertStatus(self.client.get(f"{base}test@/A/"), status.HTTP_404_NOT_FOUND)
+
     def test_update_essential_properties(self):
         # Changing the subname is expected to cause an error
         url = self.reverse(

--- a/api/desecapi/tests/test_rrsets_bulk.py
+++ b/api/desecapi/tests/test_rrsets_bulk.py
@@ -372,6 +372,33 @@ class AuthenticatedRRSetBulkTestCase(AuthenticatedRRSetBaseTestCase):
             self.assertEqual(response.data[0]["records"], ["5.4.2.1"])
             self.assertEqual(response.data[0]["ttl"], 3600)
 
+    def test_bulk_patch_is_atomic(self):
+        # A rejected bulk request must not apply the parts that were valid.
+        self.assertResponse(
+            self.client.bulk_patch_rr_sets(
+                domain_name=self.my_empty_domain.name,
+                payload=[
+                    {
+                        "subname": "valid",
+                        "type": "A",
+                        "ttl": 3620,
+                        "records": ["1.2.3.4"],
+                    },
+                    {
+                        "subname": "invalid",
+                        "type": "A",
+                        "ttl": -50,
+                        "records": ["1.2.3.4"],
+                    },
+                ],
+            ),
+            status.HTTP_400_BAD_REQUEST,
+        )
+        self.assertStatus(
+            self.client.get_rr_set(self.my_empty_domain.name, "valid", "A"),
+            status.HTTP_404_NOT_FOUND,
+        )
+
     def test_bulk_patch_full_on_empty_domain(self):
         # Full patch always works
         with self.assertRequests(

--- a/api/desecapi/tests/test_totp.py
+++ b/api/desecapi/tests/test_totp.py
@@ -58,7 +58,7 @@ class TOTPFactorTestCase(DomainOwnerTestCase):
                 assertion(response.status_code, status.HTTP_403_FORBIDDEN)
         for method in [self.client.get, self.client.post]:
             response = method(
-                self.reverse("v1:rrset@", name=self.my_domain, subname="", type="NS")
+                self.reverse("v1:rrset", name=self.my_domain, subname="", type="NS")
             )
             assertion(response.status_code, status.HTTP_403_FORBIDDEN)
 

--- a/api/desecapi/urls/version_1.py
+++ b/api/desecapi/urls/version_1.py
@@ -69,11 +69,6 @@ api_urls = [
         views.RRsetDetail.as_view(),
         kwargs={"subname": ""},
     ),
-    re_path(
-        r"^domains/(?P<name>[^/]+)/rrsets/(?P<subname>[^/]*)@/(?P<type>[^/]+)/$",
-        views.RRsetDetail.as_view(),
-        name="rrset@",
-    ),
     path("domains/<name>/rrsets/<subname>/<type>/", views.RRsetDetail.as_view()),
     # DynDNS update
     path("dyndns/update", views.DynDNS12UpdateView.as_view(), name="dyndns12update"),

--- a/test/e2e2/conftest.py
+++ b/test/e2e2/conftest.py
@@ -186,6 +186,9 @@ class DeSECAPIV1Client:
     def post(self, path: str, data: dict | None = None, **kwargs) -> requests.Response:
         return self._request("POST", path=path, data=data, **kwargs)
 
+    def put(self, path: str, data: dict | None = None, **kwargs) -> requests.Response:
+        return self._request("PUT", path=path, data=data, **kwargs)
+
     def patch(self, path: str, data: dict | None = None, **kwargs) -> requests.Response:
         return self._request("PATCH", path=path, data=data, **kwargs)
 

--- a/test/e2e2/spec/test_api_rrset_bulk_order.py
+++ b/test/e2e2/spec/test_api_rrset_bulk_order.py
@@ -1,0 +1,59 @@
+import pytest
+
+from conftest import DeSECAPIV1Client
+
+
+# The outcome of a bulk request must not depend on the order in which the RRsets
+# are given. This does not come for free: pdns refuses to add a CNAME while a
+# conflicting RRset is still present, so the API applies deletions before
+# additions regardless of their position in the payload (desec-stack#220,
+# PowerDNS/pdns#7501). The unit tests cover this against a mocked pdns and for
+# one payload order only; these tests exercise both orders against the real
+# thing (desec-stack#226).
+
+TTL = 3600
+
+CNAME_RECORDS = ['elk.example.net.']
+AAAA_RECORDS = ['::1']
+
+
+def replacement_payload(subname: str, remove_type: str, add_type: str, add_records: list) -> list:
+    """Delete one RRset and create a conflicting one at the same subname, deletion first."""
+    return [
+        {'subname': subname, 'type': remove_type, 'ttl': TTL, 'records': []},
+        {'subname': subname, 'type': add_type, 'ttl': TTL, 'records': add_records},
+    ]
+
+
+@pytest.mark.parametrize("method", ['patch', 'put'])
+@pytest.mark.parametrize("deletion_first", [True, False])
+@pytest.mark.parametrize("init_rrsets", [{('kibana', 'AAAA'): (TTL, set(AAAA_RECORDS))}])
+def test_replace_rrset_with_cname(api_user_domain_rrsets: DeSECAPIV1Client, method: str, deletion_first: bool):
+    api = api_user_domain_rrsets
+    payload = replacement_payload('kibana', 'AAAA', 'CNAME', CNAME_RECORDS)
+    if not deletion_first:
+        payload.reverse()
+
+    response = getattr(api, method)(f"/domains/{api.domain}/rrsets/", data=payload)
+    assert response.status_code == 200
+    api.assert_rrsets({
+        ('kibana', 'AAAA'): (TTL, set()),
+        ('kibana', 'CNAME'): (TTL, set(CNAME_RECORDS)),
+    })
+
+
+@pytest.mark.parametrize("method", ['patch', 'put'])
+@pytest.mark.parametrize("deletion_first", [True, False])
+@pytest.mark.parametrize("init_rrsets", [{('kibana', 'CNAME'): (TTL, set(CNAME_RECORDS))}])
+def test_replace_cname_with_rrset(api_user_domain_rrsets: DeSECAPIV1Client, method: str, deletion_first: bool):
+    api = api_user_domain_rrsets
+    payload = replacement_payload('kibana', 'CNAME', 'AAAA', AAAA_RECORDS)
+    if not deletion_first:
+        payload.reverse()
+
+    response = getattr(api, method)(f"/domains/{api.domain}/rrsets/", data=payload)
+    assert response.status_code == 200
+    api.assert_rrsets({
+        ('kibana', 'CNAME'): (TTL, set()),
+        ('kibana', 'AAAA'): (TTL, set(AAAA_RECORDS)),
+    })

--- a/test/e2e2/spec/test_api_rrset_url.py
+++ b/test/e2e2/spec/test_api_rrset_url.py
@@ -1,0 +1,59 @@
+import pytest
+
+from conftest import DeSECAPIV1Client
+
+
+# The subname part of an RRset URL can be written plainly, or terminated with
+# `...`. The zone apex has no plain form, because `rrsets//{type}/` does not
+# survive URL normalization, and is written as `@` or as `...`.
+#
+# The exhaustive matrix over subnames lives in the API test suite; what needs
+# the full stack is that these unusual characters survive the HTTP layer in
+# front of the API, and that a write made through such a URL reaches the DNS.
+
+TTL = 3600
+
+
+@pytest.mark.parametrize("subname", ['', 'www'])
+def test_url_forms_address_the_same_rrset(api_user_domain: DeSECAPIV1Client, subname: str):
+    api = api_user_domain
+    assert api.rr_set_create(api.domain, 'A', ['1.2.3.4'], subname=subname, ttl=TTL).status_code == 201
+
+    urls = [f"/domains/{api.domain}/rrsets/{subname}.../A/"]
+    urls.append(
+        f"/domains/{api.domain}/rrsets/@/A/" if not subname
+        else f"/domains/{api.domain}/rrsets/{subname}/A/"
+    )
+
+    responses = [api.get(url) for url in urls]
+    for response in responses:
+        assert response.status_code == 200
+        assert response.json()['subname'] == subname
+        assert response.json()['records'] == ['1.2.3.4']
+    assert responses[0].json() == responses[1].json()
+
+
+def test_apex_not_addressable_with_empty_subname(api_user_domain: DeSECAPIV1Client):
+    # This is the reason the '@' and '...' forms exist: the double slash does
+    # not survive URL normalization, so the apex cannot be addressed by leaving
+    # the subname empty.
+    api = api_user_domain
+    assert api.rr_set_create(api.domain, 'A', ['1.2.3.4'], ttl=TTL).status_code == 201
+
+    assert api.get(f"/domains/{api.domain}/rrsets//A/").status_code == 404
+    assert api.get(f"/domains/{api.domain}/rrsets/.../A/").status_code == 200
+
+
+def test_apex_dns(api_user_domain: DeSECAPIV1Client):
+    # Writes through the '...' URL take effect in the DNS, not just in the API.
+    api = api_user_domain
+    url = f"/domains/{api.domain}/rrsets/.../A/"
+
+    assert api.rr_set_create(api.domain, 'A', ['1.2.3.4'], ttl=TTL).status_code == 201
+    api.assert_rrsets({('', 'A'): (TTL, {'1.2.3.4'})})
+
+    assert api.patch(url, data={'records': ['5.6.7.8']}).status_code == 200
+    api.assert_rrsets({('', 'A'): (TTL, {'5.6.7.8'})})
+
+    assert api.delete(url).status_code == 204
+    api.assert_rrsets({('', 'A'): (TTL, {})})


### PR DESCRIPTION
Closes #171
Closes #226

Two commits, as discussed in review.

### 1. Drop the undocumented `{subname}@` URL form

The RRset detail endpoint accepted `rrsets/{subname}@/{type}/` as a side effect of the route that makes the zone apex addressable as `rrsets/@/{type}/`. Only the apex spelling is documented; for non-empty subnames the documented form is `rrsets/{subname}.../{type}/`, and nothing outside the test helpers used it.

The route is removed and the helpers in `base.py` now reverse the `...` form, which the suite already used elsewhere. The apex `@` form is unaffected. `rrsets/{subname}@/{type}/` falls through to the generic route, where `{subname}@` is not a valid subname, and returns 404.

### 2. Tests

The `...` form was covered by no test at all, since `base.py` reversed the `@` form throughout.

- `desecapi/tests/test_rrsets.py` covers the URL spellings over apex, plain, wildcard, dotted and underscore subnames, and that the removed form now returns 404
- `test/e2e2` keeps only what needs the full stack: that these characters survive the HTTP layer in front of the API, that the apex is not addressable by leaving the subname empty, and that a write made through such a URL reaches the DNS
- bulk ordering: the AAAA/CNAME replacement from #220 in both payload orders, for PATCH and PUT, in both directions, against the real pdns
- the positional error array turned out to be covered already by `test_bulk_patch_missing_invalid_fields_1`, so only the missing atomicity check is added next to it

`put()` is added to the e2e API client, which had `get`/`post`/`patch`/`delete` but no PUT.

### Verification

Both suites run against a full local stack, rebased on current main:

- API test suite: passes
- e2e2 suite: 338 passed, 2 skipped