### PR TITLE
feat(webapp): allow running the webapp without the stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,9 +274,12 @@ While there are certainly many ways to get started hacking desec-stack, here is 
 
 1. **Install webapp dependencies.** To install the dependencies for the web site and GUI, run
 
-       cd webapp/
+       cd www/webapp/
        npm install
        cd -
+
+    The webapp can also be run on its own, without starting the stack; see
+    [www/webapp/README.md](www/webapp/README.md).
 
 1. **Run desec-stack.** To run desec-stack, use
 

--- a/www/webapp/.env.development
+++ b/www/webapp/.env.development
@@ -1,0 +1,13 @@
+# Defaults for `npm run dev`, matching the public deSEC service that the dev
+# server proxies to (see vite.config.js). Without these, views that read them
+# fail at runtime.
+#
+# Vite reads this file in development mode only, so the production build in
+# www/Dockerfile (which passes these as build args) is unaffected. To point the
+# webapp somewhere else, override them in .env.local, which is not tracked.
+
+VITE_APP_DESECSTACK_NS=ns1.desec.io ns2.desec.org
+VITE_APP_LOCAL_PUBLIC_SUFFIXES=dedyn.io
+VITE_APP_EMAIL=support@desec.io
+VITE_APP_DESECSTACK_API_SEPA_CREDITOR_ID=TESTCREDITORID
+VITE_APP_DESECSTACK_API_SEPA_CREDITOR_NAME=TESTCREDITORNAME

--- a/www/webapp/README.md
+++ b/www/webapp/README.md
@@ -10,6 +10,28 @@ npm install
 npm run dev
 ```
 
+The webapp is then served at http://localhost:8080/.
+
+### Choosing an API
+
+The webapp calls the API at a relative URL, so the dev server forwards `/api`
+to a real API. By default this is the public one at `https://desec.io`, which
+means the webapp can be worked on without running desec-stack. Bear in mind
+that this is the production service: accounts you register and domains you
+create there are real, and it enforces rate limits that a local stack does not.
+
+To use a different API, including your own stack as set up in the top-level
+[README](../../README.md), set `DESEC_API_ORIGIN`:
+```
+DESEC_API_ORIGIN=https://desec.example.dedyn.io npm run dev
+```
+Certificate verification is skipped for such an origin, since a local stack
+usually serves a self-signed certificate. The public API is always verified.
+
+The settings that the production build takes from the environment (nameserver
+names, local public suffixes, ...) default to those of the public service, see
+`.env.development`. Override them in `.env.local`, which is not tracked by git.
+
 ### Compiles and minifies for production
 ```
 npm run build

--- a/www/webapp/vite.config.js
+++ b/www/webapp/vite.config.js
@@ -36,6 +36,18 @@ export default defineConfig({
     ],
     server: {
         port: 8080,
+        proxy: {
+            // The webapp talks to the API at a relative URL, so the dev server
+            // has to forward it somewhere. Defaults to the public API, which
+            // allows running the webapp without the stack. See README.md.
+            '/api': {
+                target: process.env.DESEC_API_ORIGIN || 'https://desec.io',
+                changeOrigin: true,
+                // A local stack usually serves a self-signed certificate. The
+                // public API is always verified.
+                secure: !process.env.DESEC_API_ORIGIN,
+            },
+        },
     },
     resolve: {
         alias: [{


### PR DESCRIPTION
Closes #397

#397 asks for README instructions to start the webapp in dev mode without the docker stack, against a sandbox or production API. That turned out not to be documentable as-is, because it does not currently work:

- The webapp calls the API at a relative URL (`baseURL: '/api/v1/'`), so `npm run dev` has nowhere to send `/api`. Vite's SPA fallback answers those calls with `index.html` — `GET http://localhost:8080/api/v1/` returns `200` and a page of HTML, so every API call fails on parsing rather than visibly.
- Several views read `VITE_APP_*` variables that only `www/Dockerfile` sets, and call `.split(' ')` on them. Without the stack they are undefined, and e.g. `/custom-setup/{domain}` throws `TypeError: Cannot read properties of undefined (reading 'split')` on load.

So this makes it work and then documents it.

### Dev server proxy

`/api` is forwarded to a real API, `https://desec.io` by default, so the webapp can be worked on with nothing else running. `DESEC_API_ORIGIN` points it elsewhere:

```
DESEC_API_ORIGIN=https://desec.example.dedyn.io npm run dev
```

Certificate verification is skipped for an explicitly given origin, since a local stack usually serves a self-signed certificate — without that, proxying to one fails with `Error: self-signed certificate`. The default public API is always verified.

### Environment defaults

`.env.development` supplies the five `VITE_APP_*` variables with values matching the public service. Vite reads `.env.development` in development mode only, so the production build is untouched: I verified the exact env value appears in what the dev server serves and does not appear anywhere in `npm run build` output.

There's a judgement call here I'm happy to revisit — this commits a working default rather than shipping a `.env.development.example` to copy. It seemed closer to what the issue asks for (`npm run dev` just works), but if you'd rather not have tracked defaults, say the word.

### Also

The top-level README told contributors to `cd webapp/`; the directory is `www/webapp/`. That step has been broken as written.

### On the sandbox question

@andreasnuesslein asked in the issue whether a sandbox API existed to point at, and the answer at the time was "not yet". I could not find one referenced anywhere in the repo or docs, so this documents the production API, with an explicit warning that accounts and domains created there are real and that it rate-limits. Happy to switch the default if a sandbox exists now.

### Verification

- `npm run dev`, `GET /api/v1/` through the dev server returns the real API root, byte-identical to querying `https://desec.io/api/v1/` directly
- `DESEC_API_ORIGIN` override checked against a stand-in HTTPS server with a self-signed certificate, before and after the `secure` handling
- `/custom-setup/example.com` loads with no uncaught errors, checked with a listener installed at document start; the same page on `main` throws the `split` TypeError
- `npm test` (4 passed) and `npm run build` both fine