### PR TITLE
fix(webapp): basic accessibility improvements

### DIFF
--- a/www/webapp/src/App.vue
+++ b/www/webapp/src/App.vue
@@ -47,7 +47,12 @@
       <v-btn class="mx-4" color="primary" variant="flat" :to="{name: 'signup', query: $route.query}" v-if="!authenticated">Create Account</v-btn>
       <v-btn class="mx-4 ml-0" color="primary" variant="flat" :to="{name: 'login'}" v-if="!authenticated">Log In</v-btn>
       <v-btn class="mx-4 ml-0" color="primary" variant="outlined" @click="logout" v-if="authenticated">Log Out</v-btn>
-      <v-app-bar-nav-icon class="d-md-none" @click.stop="drawer = !drawer" />
+      <v-app-bar-nav-icon
+              class="d-md-none"
+              aria-label="Navigation menu"
+              :aria-expanded="String(drawer)"
+              @click.stop="drawer = !drawer"
+      />
       <template #extension v-if="authenticated">
         <div class="authenticated-tabs d-flex align-center w-100 bg-primary text-white">
           <v-tabs v-model="activeTab" class="flex-grow-1 text-white" bg-color="primary" color="white" slider-color="white" grow>
@@ -116,11 +121,17 @@
           </v-btn>
         </template>
       </v-banner>
+      <!--
+        Purely decorative: it appears on every request, and announcing that is
+        more noise than help. Screen reader users learn the outcome from the
+        result itself (or from an error alert).
+      -->
       <v-progress-linear
               :active="user.working"
               :indeterminate="user.working"
               color="secondary"
               style="z-index: 3"
+              aria-hidden="true"
       ></v-progress-linear>
       <router-view/>
     </v-main>

--- a/www/webapp/src/views/ChangeEmail.vue
+++ b/www/webapp/src/views/ChangeEmail.vue
@@ -22,7 +22,7 @@
                                 color="primary"
                                 flat
                         >
-                            <v-toolbar-title>Change Account Email Address</v-toolbar-title>
+                            <v-toolbar-title tag="h1">Change Account Email Address</v-toolbar-title>
                         </v-toolbar>
                         <v-card-text>
                             <error-alert :errors="errors"></error-alert>

--- a/www/webapp/src/views/ConfirmationPage.vue
+++ b/www/webapp/src/views/ConfirmationPage.vue
@@ -17,7 +17,7 @@
                   color="primary"
                   flat
           >
-            <v-toolbar-title class="capitalize">{{ actionName }} Confirmation</v-toolbar-title>
+            <v-toolbar-title class="capitalize" tag="h1">{{ actionName }} Confirmation</v-toolbar-title>
           </v-toolbar>
           <v-card-text>
             <error-alert :errors="errors"></error-alert>

--- a/www/webapp/src/views/Console/DomainSetupDialog.vue
+++ b/www/webapp/src/views/Console/DomainSetupDialog.vue
@@ -8,11 +8,18 @@
   >
     <v-card>
       <v-card-title class="domain-setup-title">
-        <div class="text-h6">
+        <h2 class="text-h6">
           Setup Instructions for <b>{{ domain }}</b>
-        </div>
+        </h2>
         <v-spacer/>
-        <v-icon :icon="mdiClose" @click.stop="close" />
+        <v-btn
+            icon
+            variant="text"
+            aria-label="Close dialog"
+            @click.stop="close"
+        >
+          <v-icon :icon="mdiClose" />
+        </v-btn>
       </v-card-title>
       <v-divider/>
 

--- a/www/webapp/src/views/Console/TOTPVerifyDialog.vue
+++ b/www/webapp/src/views/Console/TOTPVerifyDialog.vue
@@ -9,9 +9,9 @@
     <v-form @submit.prevent="verify" ref="form">
       <v-card>
         <v-card-title class="d-flex align-center">
-          <span class="text-h6">
+          <h2 class="text-h6">
             Verify TOTP: <b>{{ displayName }}</b>
-          </span>
+          </h2>
           <v-spacer/>
           <v-btn
             icon

--- a/www/webapp/src/views/CrudList.vue
+++ b/www/webapp/src/views/CrudList.vue
@@ -36,7 +36,7 @@
             <template #top>
               <!-- Headline & Toolbar, Including New Form -->
               <v-toolbar class="bg-white" flat>
-                <v-toolbar-title>{{ headlines.table }}</v-toolbar-title>
+                <v-toolbar-title tag="h1">{{ headlines.table }}</v-toolbar-title>
                 <v-spacer />
                 <v-text-field
                         v-model="search"
@@ -61,6 +61,7 @@
                         size="small"
                         icon
                         variant="flat"
+                        :aria-label="headlines.create"
                         :disabled="user.working"
                 >
                   <v-icon :icon="mdiPlus" />
@@ -86,9 +87,17 @@
                   <v-card>
                     <v-form ref="createForm" v-model="valid" @submit.prevent="save()">
                       <v-card-title>
-                        <span class="text-h5">{{ headlines.create }}</span>
+                        <!-- d-inline keeps the previous <span> layout; only the semantics change -->
+                        <h2 class="text-h5 d-inline">{{ headlines.create }}</h2>
                         <v-spacer />
-                        <v-icon :icon="mdiClose" @click.stop="close" />
+                        <v-btn
+                                icon
+                                variant="text"
+                                aria-label="Close dialog"
+                                @click.stop="close"
+                        >
+                          <v-icon :icon="mdiClose" />
+                        </v-btn>
                       </v-card-title>
                       <v-divider />
                       <v-progress-linear
@@ -280,7 +289,7 @@
             <v-card>
               <v-form @submit.prevent="destroy(destroyDialogItem)">
                 <v-card-title>
-                  <span class="text-h5">{{ headlines.destroy }}</span>
+                  <h2 class="text-h5 d-inline">{{ headlines.destroy }}</h2>
                 </v-card-title>
 
                 <v-divider />

--- a/www/webapp/src/views/DeleteAccount.vue
+++ b/www/webapp/src/views/DeleteAccount.vue
@@ -22,7 +22,7 @@
                                 color="primary"
                                 flat
                         >
-                            <v-toolbar-title>Delete Account</v-toolbar-title>
+                            <v-toolbar-title tag="h1">Delete Account</v-toolbar-title>
                         </v-toolbar>
                         <v-card-text>
                             <error-alert :errors="errors"></error-alert>

--- a/www/webapp/src/views/DomainSetup.vue
+++ b/www/webapp/src/views/DomainSetup.vue
@@ -10,10 +10,10 @@
     </p>
 
     <div v-if="!user.authenticated">
-      <div class="my-2 text-h6">
+      <h2 class="my-2 text-h6">
         <v-icon class="text-primary" :icon="mdiNumeric0Circle" />
         Configure your DNS records
-      </div>
+      </h2>
       <p>Before delegating your domain, you might want to take the following steps:</p>
       <ul>
         <li><router-link :to="{name: 'reset-password'}" target="_blank">Set up a password for your deSEC account</router-link>,</li>
@@ -22,10 +22,10 @@
       </ul>
     </div>
 
-    <div class="mb-2 mt-5 text-h6">
+    <h2 class="mb-2 mt-5 text-h6">
       <v-icon class="text-primary" :icon="mdiNumeric1Circle" />
       Delegate your domain
-    </div>
+    </h2>
     <p>
       Forward the following information to the organization/person where you bought the domain
       <strong>{{ domain }}</strong> (usually your provider or technical administrator).
@@ -73,10 +73,10 @@
     </v-card>
     <p>Once your provider processes this information, the Internet will start directing DNS queries to deSEC.</p>
 
-    <div class="mb-2 mt-5 text-h6">
+    <h2 class="mb-2 mt-5 text-h6">
       <v-icon class="text-primary" :icon="mdiNumeric2Circle" />
       Enable DNSSEC
-    </div>
+    </h2>
     <div v-if="user.authenticated">
       <p>
         You also need to forward the following DNSSEC information to your domain provider.
@@ -130,10 +130,10 @@
         <v-alert type="error" v-else>Parameters could not be retrieved. (Are you logged in?)</v-alert>
       </v-card>
 
-      <div class="mb-2 mt-5 text-h6">
+      <h2 class="mb-2 mt-5 text-h6">
         <v-icon class="text-primary" :icon="mdiNumeric3Circle" />
         Check Setup
-      </div>
+      </h2>
       <p>
         All set up correctly? <a :href="`https://dnssec-analyzer.verisignlabs.com/${domain}`" target="_blank">Take a
         look at DNSSEC Analyzer</a> to check the status of your domain.

--- a/www/webapp/src/views/DomainSetupPage.vue
+++ b/www/webapp/src/views/DomainSetupPage.vue
@@ -7,7 +7,7 @@
               color="primary"
               flat
           >
-            <v-toolbar-title>Setup Instructions for <b>{{ domain }}</b></v-toolbar-title>
+            <v-toolbar-title tag="h1">Setup Instructions for <b>{{ domain }}</b></v-toolbar-title>
           </v-toolbar>
 
           <v-card-text>
@@ -20,7 +20,7 @@
     <v-row align="center" justify="center">
       <v-col cols="12" sm="8" md="3">
         <v-card>
-          <v-card-title><div class="text-h6">Find Help</div></v-card-title>
+          <v-card-title><h2 class="text-h6">Find Help</h2></v-card-title>
           <v-card-text>
             In our forum <router-link :to="{name: 'talk'}">talk.desec.io</router-link>, members of the community
             discuss ideas and applications of deSEC. If you have a question, chances are that you may be able to find
@@ -33,7 +33,7 @@
       </v-col>
       <v-col cols="12" sm="8" md="3">
         <v-card>
-          <v-card-title><div class="text-h6">Keep deSEC Going</div></v-card-title>
+          <v-card-title><h2 class="text-h6">Keep deSEC Going</h2></v-card-title>
           <v-card-text>
             To offer free DNS hosting for everyone, deSEC relies on donations only.
             If you like our service, please consider donating.

--- a/www/webapp/src/views/DonatePage.vue
+++ b/www/webapp/src/views/DonatePage.vue
@@ -18,7 +18,7 @@
                   color="primary"
                   flat
           >
-            <v-toolbar-title>Donate</v-toolbar-title>
+            <v-toolbar-title tag="h2">Donate</v-toolbar-title>
           </v-toolbar>
           <v-card-text>
             <v-expansion-panels class="mb-4">
@@ -158,7 +158,7 @@
               <strong>Based in Europe?</strong> You almost certainly can donate via direct debit or bank transfer (you
               only need your IBAN). <strong>No fees</strong> will be subtracted, so you can do more good!
             </p>
-            <div class="text-h6">Donation Receipts</div>
+            <h2 class="text-h6">Donation Receipts</h2>
             <p>
               deSEC e.V. is registered as a charitable organization in Germany. If you pay taxes here, your donation is
               tax-deductible, and we're happy to provide you with a donation receipt for that purpose. Note that for
@@ -173,7 +173,7 @@
                   color="primary"
                   flat
           >
-            <v-toolbar-title>Support our Quest</v-toolbar-title>
+            <v-toolbar-title tag="h2">Support our Quest</v-toolbar-title>
           </v-toolbar>
           <v-card-text>
             <p>

--- a/www/webapp/src/views/DynSetup.vue
+++ b/www/webapp/src/views/DynSetup.vue
@@ -17,7 +17,7 @@
                   color="primary"
                   flat
           >
-            <v-toolbar-title>Domain Registration Completed</v-toolbar-title>
+            <v-toolbar-title tag="h1">Domain Registration Completed</v-toolbar-title>
           </v-toolbar>
           <v-card-text>
             <error-alert :errors="errors"></error-alert>

--- a/www/webapp/src/views/LoginPage.vue
+++ b/www/webapp/src/views/LoginPage.vue
@@ -22,7 +22,7 @@
                     color="primary"
                     flat
             >
-              <v-toolbar-title>Log In</v-toolbar-title>
+              <v-toolbar-title tag="h1">Log In</v-toolbar-title>
             </v-toolbar>
             <v-card-text>
               <error-alert :errors="errors"></error-alert>

--- a/www/webapp/src/views/MFA.vue
+++ b/www/webapp/src/views/MFA.vue
@@ -8,9 +8,9 @@
     <v-form @submit.prevent="verify" ref="form">
       <v-card>
         <v-card-title>
-          <div class="text-h6">
+          <h1 class="text-h6">
             2FA Required
-          </div>
+          </h1>
           <v-spacer/>
         </v-card-title>
         <v-divider/>

--- a/www/webapp/src/views/ResetPassword.vue
+++ b/www/webapp/src/views/ResetPassword.vue
@@ -22,7 +22,7 @@
                                 color="primary"
                                 flat
                         >
-                            <v-toolbar-title>Reset Account Password</v-toolbar-title>
+                            <v-toolbar-title tag="h1">Reset Account Password</v-toolbar-title>
                         </v-toolbar>
                         <v-card-text>
                             <error-alert :errors="errors"></error-alert>

--- a/www/webapp/src/views/SignUp.vue
+++ b/www/webapp/src/views/SignUp.vue
@@ -23,7 +23,7 @@
                     color="primary"
                     flat
             >
-              <v-toolbar-title>Create new Account</v-toolbar-title>
+              <v-toolbar-title tag="h1">Create new Account</v-toolbar-title>
             </v-toolbar>
             <v-card-text>
               <error-alert :errors="errors"></error-alert>

--- a/www/webapp/src/views/WelcomePage.vue
+++ b/www/webapp/src/views/WelcomePage.vue
@@ -17,7 +17,7 @@
                   color="primary"
                   flat
           >
-            <v-toolbar-title>Welcome to deSEC</v-toolbar-title>
+            <v-toolbar-title tag="h1">Welcome to deSEC</v-toolbar-title>
           </v-toolbar>
           <v-card-text>
             <v-alert type="success">


### PR DESCRIPTION
Closes #472

This picks up the three items in #472. It builds on #890 by @xyhhx, which got a review but went quiet and no longer merges after the Vuetify 3 migration. Following that review, accessible names are added only where there is **no** visible text, rather than duplicating text the accessible name is already computed from — a `<v-btn aria-label="Log In">Log In</v-btn>` gains nothing and can hurt voice control.

### Accessible names

- The mobile navigation toggle in `App.vue` had no name (it shows as a bare `button` with an `img` in the accessibility tree). It now has `aria-label` plus `aria-expanded`, since it toggles the drawer.
- The create button in the CRUD lists (domains, tokens) is icon-only and unnamed; it now uses the list's own `headlines.create`, so it reads as "Create New Domain" rather than nothing.
- Two dialog close controls were bare `<v-icon>` elements carrying a click handler. Those are not focusable and not exposed as controls at all, so the dialogs could not be closed by keyboard via that affordance. They now use the same `v-btn icon variant="text" aria-label="Close dialog"` pattern already used by the close control in `TOTPVerifyDialog.vue`.

Worth noting what is *not* here: the show/hide password toggles get Vuetify's generated name, "Password appended action". That is poor but not missing, and fixing it properly means replacing five `@click:append-inner` handlers with labelled buttons in the `append-inner` slot. Happy to do it in a follow-up if you want it.

### Headings

The page titles were `<v-toolbar-title>`, which renders a `<div>`. The login page, for example, had **no heading element at all**, so there was nothing to navigate by. Vuetify's `tag` prop fixes this with no visual change:

- 10 page titles become `<h1>`; the two on the donate page become `<h2>`, since that page already has an `<h1>`
- the four numbered step titles on the domain setup page become `<h2>`

`/custom-setup/{domain}` went from zero headings to:

```
H1 Setup Instructions for example.com
  H2 Configure your DNS records
  H2 Delegate your domain
  H2 Enable DNSSEC
  H2 Find Help
  H2 Keep deSEC Going
```

This is what @robin24 suggested in the issue thread.

### Progress bar

@nils-wisiol asked why it was irritating and couldn't see it visually. The reason isn't visual. `VProgressLinear` renders `aria-hidden="false"` whenever it is active, so on every single request an unnamed `progressbar` enters the accessibility tree and leaves again. It carries no information a screen reader user can act on — the outcome is announced by the result or the error alert — so it is marked decorative.

That keeps the bar exactly as it is for sighted users, rather than removing it as was floated. If you'd rather it went away entirely, or want a spinner instead as @peterthomassen suggested, say so and I'll change it.

### Verification

Checked in a browser against the accessibility tree and the DOM, not just by reading source:

- login page before: no heading, unnamed nav button. After: `H1 Log In`, nav button named with `aria-expanded`
- progress bar A/B with `work_count` driven directly: on `main` it is `aria-hidden="false"` while working; with this branch it stays `"true"`. Visual state (`height: 0`, no `--active` class) is identical on both, so this changes assistive-technology exposure and nothing else
- donate page outline verified as H1 → H2, no unnamed buttons
- `npm run build` and `npm test` (4 passed) pass

Two caveats I'd rather state than paper over. The CRUD create/destroy dialogs and `DomainSetupDialog` are behind login, so I verified those by source and by matching the existing `TOTPVerifyDialog` pattern, not visually. And where a heading replaced an inline `<span>` inside a `v-card-title` (which is `display: block`), I kept `d-inline` on the heading so the layout is byte-identical rather than adding flex — semantics change, appearance does not.

Unrelated, noticed while working: `npm run lint` fails on `main` too, because the glob `src/**/*.{vue,js,json}` matches `src/modules/qrcode.vue`, which is a directory. Left alone here.