### PR TITLE
fix(webapp): make the lint script work

### DIFF
--- a/www/webapp/package.json
+++ b/www/webapp/package.json
@@ -8,8 +8,8 @@
     "build": "vite build",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint --ignore-path .gitignore --no-fix src/**/*.{vue,js,json}",
-    "lint:fix": "eslint --ignore-path .gitignore --fix src/**/*.{vue,js,json}",
+    "lint": "eslint --ignore-path .gitignore --no-fix \"src/**/*.{vue,js,json}\"",
+    "lint:fix": "eslint --ignore-path .gitignore --fix \"src/**/*.{vue,js,json}\"",
     "postinstall": "vue-demi-switch 3"
   },
   "type": "module",

--- a/www/webapp/src/components/Field/RecordDS.vue
+++ b/www/webapp/src/components/Field/RecordDS.vue
@@ -1,5 +1,5 @@
 <script>
-import { and, helpers, integer, between } from '@vuelidate/validators';
+import { helpers, integer, between } from '@vuelidate/validators';
 import RecordItem from './RecordItem.vue';
 import { dnskey_algorithm_mnemonics } from './RecordDNSKEY.vue';
 

--- a/www/webapp/src/components/Field/RecordTLSA.vue
+++ b/www/webapp/src/components/Field/RecordTLSA.vue
@@ -1,5 +1,5 @@
 <script>
-import { and, helpers, integer, between } from '@vuelidate/validators';
+import { helpers, integer, between } from '@vuelidate/validators';
 import RecordItem from './RecordItem.vue';
 
 const hex = helpers.regex(/^([0-9a-fA-F]\s*)*[0-9a-fA-F]$/);


### PR DESCRIPTION
`npm run lint` currently fails on `main`, before it lints anything:

```
$ npm run lint
> eslint --ignore-path .gitignore --no-fix src/**/*.{vue,js,json}

No files matching the pattern "src/modules/qrcode.vue" were found.
```

### Why

The glob is unquoted, so the **shell** expands it and passes the results to eslint as explicit targets. One of them is `src/modules/qrcode.vue` — the vendored copy of the qrcode.vue library, which is a *directory*, not a file. Everything inside it is excluded via `ignorePatterns: ['**/src/modules/**/*']` in `.eslintrc.cjs`, so eslint finds nothing to lint under a target it was explicitly given, and errors out.

The exclusion itself is correct; it's the shell expansion that trips over the directory name.

### Fix

Quote the pattern so eslint expands it. That skips the directory, and has a second effect worth calling out: `sh` has no globstar, so `src/**/*` behaved as `src/*/*` and only ever reached **one** directory level. `src/components/Field/` and `src/views/Console/` — 31 files — were never linted at all. With eslint doing the globbing, `**` is a real globstar:

- before: 38 targets, one of which was the directory that caused the failure
- after: 73 files actually linted, vendored code still excluded (verified: 0 files under `src/modules/` are linted)

The added coverage surfaced exactly one pre-existing error, an unused `and` import in `RecordDS.vue` and `RecordTLSA.vue`. Removed here so the script exits clean; nothing else needed fixing.

### Checks

- `npm run lint` exits 0
- `npm run lint:fix` produces no further changes
- `npm run build` and `npm test` (4 passed) unaffected

Sidenote, not addressed here: nothing in `.github/workflows/test.yml` runs `lint`, which is presumably how this went unnoticed. Happy to add a step if you'd like it.